### PR TITLE
[Feature] Robust sorting — Watched Date & My Highest Rated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,7 +201,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -211,7 +211,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -245,7 +245,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -327,7 +327,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -354,11 +354,13 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -370,11 +372,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -386,11 +390,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -402,11 +408,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -418,11 +426,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -434,11 +444,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -450,11 +462,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -466,11 +480,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -482,11 +498,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -498,11 +516,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -514,11 +534,13 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -530,11 +552,13 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -546,11 +570,13 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -562,11 +588,13 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -578,11 +606,13 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -594,11 +624,13 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -610,11 +642,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -626,11 +660,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -642,11 +678,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -658,11 +696,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -674,11 +714,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -690,11 +732,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -706,11 +750,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -722,11 +768,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -738,11 +786,13 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -754,11 +804,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5438,7 +5490,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",

--- a/packages/backend/src/movies/movie-routes.ts
+++ b/packages/backend/src/movies/movie-routes.ts
@@ -15,7 +15,7 @@ const listQuerySchema = z.object({
   search: z.string().optional(),
   tmdb_id: z.coerce.number().int().positive().optional(),
   page: z.coerce.number().int().positive().default(1),
-  sort_by: z.enum(['popularity', 'rating']).default('popularity'),
+  sort_by: z.enum(['popularity', 'rating', 'watched_date', 'my_rating']).default('popularity'),
   user_filter: z
     .string()
     .transform(raw => raw.split(',').filter(Boolean))
@@ -68,7 +68,11 @@ export const movieRoutes: FastifyPluginCallbackZod = (fastify, _options, done) =
       }
 
       const userDataService = createUserDataService({ logger: request.log });
-      const tmdbIds = await userDataService.getFilteredTmdbIds(request.user.userId, user_filter);
+      const tmdbIds = await userDataService.getFilteredTmdbIds(
+        request.user.userId,
+        user_filter,
+        sort_by
+      );
 
       if (tmdbIds.length === 0) {
         return reply.send({ results: [], page: 1, total_pages: 1, total_results: 0 });

--- a/packages/backend/src/movies/movie-routes.ts
+++ b/packages/backend/src/movies/movie-routes.ts
@@ -8,6 +8,7 @@ import { createWatchService } from '../watch/watch-service.js';
 import { createRatingService } from '../ratings/rating-service.js';
 import { createReviewService } from '../reviews/review-service.js';
 import { USER_FILTER_VALUES } from './movie-types.js';
+import type { SortBy, UserFilterValue } from './movie-types.js';
 
 const PAGE_SIZE = 20;
 
@@ -44,9 +45,21 @@ function handleNotFound(error: unknown): never {
   throw error;
 }
 
+const SORT_REQUIRED_FILTER: Partial<Record<SortBy, UserFilterValue>> = {
+  watched_date: 'watched',
+  my_rating: 'rated',
+};
+
 export const movieRoutes: FastifyPluginCallbackZod = (fastify, _options, done) => {
   fastify.get('/', { schema: { querystring: listQuerySchema } }, async (request, reply) => {
     const { tmdb_id, search, page, sort_by, user_filter } = request.query;
+
+    const requiredFilter = SORT_REQUIRED_FILTER[sort_by];
+    if (requiredFilter !== undefined && !user_filter?.includes(requiredFilter)) {
+      return reply
+        .code(400)
+        .send({ error: `sort_by=${sort_by} requires user_filter to include "${requiredFilter}"` });
+    }
 
     if (tmdb_id !== undefined) {
       const movieService = createMovieService({ logger: request.log });

--- a/packages/backend/src/movies/movie-types.ts
+++ b/packages/backend/src/movies/movie-types.ts
@@ -72,7 +72,7 @@ export interface MovieDetail extends MovieListItem {
   rtSearchUrl: string;
 }
 
-export type SortBy = 'popularity' | 'rating';
+export type SortBy = 'popularity' | 'rating' | 'watched_date' | 'my_rating';
 
 export const USER_FILTER_VALUES = ['rated', 'watched', 'reviewed'] as const;
 export type UserFilterValue = (typeof USER_FILTER_VALUES)[number];

--- a/packages/backend/src/movies/user-data-service.ts
+++ b/packages/backend/src/movies/user-data-service.ts
@@ -54,12 +54,12 @@ export function createUserDataService(options?: ServiceOptions) {
           select: { tmdbId: true },
         });
         const orderedIds = entries.map(entry => entry.tmdbId);
-        const additionalFilters = filters.filter(filter => filter !== 'watched');
-        if (additionalFilters.length === 0) return orderedIds;
-        const additionalIdSets = await Promise.all(
-          additionalFilters.map(filter => fetchIdsForFilter(userId, filter))
+        const intersectionFilters = filters.filter(filter => filter !== 'watched');
+        if (intersectionFilters.length === 0) return orderedIds;
+        const intersectionIdSets = await Promise.all(
+          intersectionFilters.map(filter => fetchIdsForFilter(userId, filter))
         );
-        const additionalIds = new Set(additionalIdSets.flat());
+        const additionalIds = new Set(intersectionIdSets.flat());
         return orderedIds.filter((id: number) => additionalIds.has(id));
       }
 
@@ -70,12 +70,12 @@ export function createUserDataService(options?: ServiceOptions) {
           select: { tmdbId: true },
         });
         const orderedIds = entries.map(entry => entry.tmdbId);
-        const additionalFilters = filters.filter(filter => filter !== 'rated');
-        if (additionalFilters.length === 0) return orderedIds;
-        const additionalIdSets = await Promise.all(
-          additionalFilters.map(filter => fetchIdsForFilter(userId, filter))
+        const intersectionFilters = filters.filter(filter => filter !== 'rated');
+        if (intersectionFilters.length === 0) return orderedIds;
+        const intersectionIdSets = await Promise.all(
+          intersectionFilters.map(filter => fetchIdsForFilter(userId, filter))
         );
-        const additionalIds = new Set(additionalIdSets.flat());
+        const additionalIds = new Set(intersectionIdSets.flat());
         return orderedIds.filter((id: number) => additionalIds.has(id));
       }
 

--- a/packages/backend/src/movies/user-data-service.ts
+++ b/packages/backend/src/movies/user-data-service.ts
@@ -50,19 +50,33 @@ export function createUserDataService(options?: ServiceOptions) {
       if (sortBy === 'watched_date') {
         const entries = await prisma.watchEntry.findMany({
           where: { userId },
-          orderBy: { watchedAt: 'desc' },
+          orderBy: [{ watchedAt: 'desc' }, { tmdbId: 'desc' }],
           select: { tmdbId: true },
         });
-        return entries.map(entry => entry.tmdbId);
+        const orderedIds = entries.map(entry => entry.tmdbId);
+        const additionalFilters = filters.filter(filter => filter !== 'watched');
+        if (additionalFilters.length === 0) return orderedIds;
+        const additionalIdSets = await Promise.all(
+          additionalFilters.map(filter => fetchIdsForFilter(userId, filter))
+        );
+        const additionalIds = new Set(additionalIdSets.flat());
+        return orderedIds.filter((id: number) => additionalIds.has(id));
       }
 
       if (sortBy === 'my_rating') {
         const entries = await prisma.rating.findMany({
           where: { userId },
-          orderBy: { score: 'desc' },
+          orderBy: [{ score: 'desc' }, { tmdbId: 'desc' }],
           select: { tmdbId: true },
         });
-        return entries.map(entry => entry.tmdbId);
+        const orderedIds = entries.map(entry => entry.tmdbId);
+        const additionalFilters = filters.filter(filter => filter !== 'rated');
+        if (additionalFilters.length === 0) return orderedIds;
+        const additionalIdSets = await Promise.all(
+          additionalFilters.map(filter => fetchIdsForFilter(userId, filter))
+        );
+        const additionalIds = new Set(additionalIdSets.flat());
+        return orderedIds.filter((id: number) => additionalIds.has(id));
       }
 
       const idSets = await Promise.all(filters.map(filter => fetchIdsForFilter(userId, filter)));

--- a/packages/backend/src/movies/user-data-service.ts
+++ b/packages/backend/src/movies/user-data-service.ts
@@ -2,7 +2,7 @@ import type { FastifyBaseLogger } from 'fastify';
 import type { Logger } from 'pino';
 import { LOGGER } from '../registry.js';
 import { prisma } from '../lib/prisma.js';
-import type { UserFilterValue } from './movie-types.js';
+import type { SortBy, UserFilterValue } from './movie-types.js';
 
 type ServiceLogger = Logger | FastifyBaseLogger;
 
@@ -16,37 +16,57 @@ export function createUserDataService(options?: ServiceOptions) {
   const localLogger = (context: string) =>
     serviceLogger.child({ module: 'user-data-service', context });
 
+  async function fetchIdsForFilter(userId: number, filter: UserFilterValue): Promise<number[]> {
+    if (filter === 'rated') {
+      const records = await prisma.rating.findMany({
+        where: { userId },
+        select: { tmdbId: true },
+      });
+      return records.map(record => record.tmdbId);
+    }
+    if (filter === 'watched') {
+      const records = await prisma.watchEntry.findMany({
+        where: { userId },
+        select: { tmdbId: true },
+      });
+      return records.map(record => record.tmdbId);
+    }
+    const records = await prisma.review.findMany({
+      where: { userId },
+      select: { tmdbId: true },
+    });
+    return records.map(record => record.tmdbId);
+  }
+
   return {
-    async getFilteredTmdbIds(userId: number, filters: UserFilterValue[]): Promise<number[]> {
+    async getFilteredTmdbIds(
+      userId: number,
+      filters: UserFilterValue[],
+      sortBy?: SortBy
+    ): Promise<number[]> {
       const logger = localLogger('getFilteredTmdbIds');
-      logger.debug({ userId, filters }, 'Fetching filtered tmdb IDs');
+      logger.debug({ userId, filters, sortBy }, 'Fetching filtered tmdb IDs');
 
-      const idSets = await Promise.all(
-        filters.map(async filter => {
-          if (filter === 'rated') {
-            const records = await prisma.rating.findMany({
-              where: { userId },
-              select: { tmdbId: true },
-            });
-            return records.map(({ tmdbId }: { tmdbId: number }) => tmdbId);
-          }
-          if (filter === 'watched') {
-            const records = await prisma.watchEntry.findMany({
-              where: { userId },
-              select: { tmdbId: true },
-            });
-            return records.map(({ tmdbId }: { tmdbId: number }) => tmdbId);
-          }
-          const records = await prisma.review.findMany({
-            where: { userId },
-            select: { tmdbId: true },
-          });
-          return records.map(({ tmdbId }: { tmdbId: number }) => tmdbId);
-        })
-      );
+      if (sortBy === 'watched_date') {
+        const entries = await prisma.watchEntry.findMany({
+          where: { userId },
+          orderBy: { watchedAt: 'desc' },
+          select: { tmdbId: true },
+        });
+        return entries.map(entry => entry.tmdbId);
+      }
 
-      const unique = new Set(idSets.flat());
-      return Array.from(unique);
+      if (sortBy === 'my_rating') {
+        const entries = await prisma.rating.findMany({
+          where: { userId },
+          orderBy: { score: 'desc' },
+          select: { tmdbId: true },
+        });
+        return entries.map(entry => entry.tmdbId);
+      }
+
+      const idSets = await Promise.all(filters.map(filter => fetchIdsForFilter(userId, filter)));
+      return Array.from(new Set(idSets.flat()));
     },
 
     async getUserMovieData(tmdbId: number, userId: number) {

--- a/packages/frontend/src/components/movies/MovieSearch.tsx
+++ b/packages/frontend/src/components/movies/MovieSearch.tsx
@@ -62,6 +62,12 @@ export default function MovieSearch({
           <SelectContent>
             <SelectItem value="popularity">Most Popular</SelectItem>
             <SelectItem value="rating">Highest Rated</SelectItem>
+            <SelectItem value="watched_date" disabled={!userFilters.includes('watched')}>
+              My Watched Date
+            </SelectItem>
+            <SelectItem value="my_rating" disabled={!userFilters.includes('rated')}>
+              My Highest Rated
+            </SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/packages/frontend/src/pages/movies/MoviesPage.tsx
+++ b/packages/frontend/src/pages/movies/MoviesPage.tsx
@@ -50,9 +50,14 @@ export default function MoviesPage() {
   };
 
   const handleFilterChange = (filter: UserFilter) => {
-    setUserFilters(prev =>
-      prev.includes(filter) ? prev.filter(f => f !== filter) : [...prev, filter]
+    const isRemoving = userFilters.includes(filter);
+    setUserFilters(currentFilters =>
+      isRemoving ? currentFilters.filter(f => f !== filter) : [...currentFilters, filter]
     );
+    if (isRemoving) {
+      if (filter === 'watched' && sortBy === 'watched_date') setSortBy('popularity');
+      if (filter === 'rated' && sortBy === 'my_rating') setSortBy('popularity');
+    }
     setPage(1);
   };
 

--- a/packages/frontend/src/types/movie.ts
+++ b/packages/frontend/src/types/movie.ts
@@ -38,6 +38,6 @@ export interface UserMovieData {
   review: { content: string } | null;
 }
 
-export type SortBy = 'popularity' | 'rating';
+export type SortBy = 'popularity' | 'rating' | 'watched_date' | 'my_rating';
 
 export type UserFilter = 'rated' | 'watched' | 'reviewed';


### PR DESCRIPTION
### Summary

Expands the movie list sort options with two user-specific sorts: **My Watched Date** and **My Highest Rated**.

### Changes

**Backend**
- Extended `SortBy` type to include `watched_date` and `my_rating`
- Updated route query schema to accept the new sort values
- `getFilteredTmdbIds` now handles the new sorts by querying `WatchEntry` ordered by `watchedAt DESC` and `Rating` ordered by `score DESC` directly in Prisma, replacing the previous manual union/intersection logic

**Frontend**
- Added **My Watched Date** and **My Highest Rated** to the sort dropdown
- Both options are disabled (greyed out) when their corresponding filter (**Watched by me** / **Rated by me**) is not active
- Deactivating a filter that the current sort depends on automatically resets the sort to **Most Popular**

### Notes

- Sorting by `watched_date` or `my_rating` bypasses the general filter union path and queries directly from the user's watch/rating records — no extra N+1 TMDB calls are introduced beyond the existing pagination slice