### PR TITLE
feat: add ratings import from filmtipset.se  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .env
+*.csv

--- a/package-lock.json
+++ b/package-lock.json
@@ -201,7 +201,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -211,7 +211,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -245,7 +245,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -327,7 +327,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -354,13 +354,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -372,13 +370,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -390,13 +386,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -408,13 +402,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -426,13 +418,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -444,13 +434,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -462,13 +450,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -480,13 +466,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -498,13 +482,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -516,13 +498,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -534,13 +514,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -552,13 +530,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -570,13 +546,11 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -588,13 +562,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -606,13 +578,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -624,13 +594,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -642,13 +610,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -660,13 +626,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -678,13 +642,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -696,13 +658,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -714,13 +674,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -732,13 +690,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -750,13 +706,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -768,13 +722,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -786,13 +738,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -804,13 +754,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4006,6 +3954,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -5490,7 +5444,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -8229,6 +8183,7 @@
         "@fastify/jwt": "^10.0.0",
         "@prisma/client": "^6.0.0",
         "bcryptjs": "^2.4.3",
+        "csv-parse": "^6.2.1",
         "fastify": "^5.0.0",
         "fastify-type-provider-zod": "^6.1.0",
         "got": "^14.0.0",

--- a/packages/backend/eslint.config.js
+++ b/packages/backend/eslint.config.js
@@ -1,8 +1,11 @@
-// @ts-check
-
 import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineConfig(
   {
@@ -32,6 +35,7 @@ export default defineConfig(
     languageOptions: {
       parserOptions: {
         projectService: true,
+        tsconfigRootDir: __dirname,
       },
     },
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -39,6 +39,7 @@
     "@fastify/jwt": "^10.0.0",
     "@prisma/client": "^6.0.0",
     "bcryptjs": "^2.4.3",
+    "csv-parse": "^6.2.1",
     "fastify": "^5.0.0",
     "fastify-type-provider-zod": "^6.1.0",
     "got": "^14.0.0",

--- a/packages/backend/src/movies/import-service.spec.ts
+++ b/packages/backend/src/movies/import-service.spec.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test';
+process.env.TMDB_API_KEY = 'test-tmdb-key';
+process.env.OMDB_API_KEY = 'test-omdb-key';
+process.env.JWT_SECRET = 'test-jwt-secret-with-at-least-32-chars!!';
+
+let normalizeImdbId: (value: string) => string | null;
+let parseFilmtipsetRows: any;
+
+beforeAll(async () => {
+  const importService = await import('./import-service.js');
+  normalizeImdbId = importService.normalizeImdbId;
+  parseFilmtipsetRows = importService.parseFilmtipsetRows;
+});
+
+afterAll(() => {
+  Object.assign(process.env, originalEnv);
+});
+
+describe('import service helpers', () => {
+  it('normalizes a 6-digit numeric value into a valid IMDB id', () => {
+    expect(normalizeImdbId('455590')).toBe('tt0455590');
+  });
+
+  it('returns null for values shorter than 4 digits or longer than 7 digits', () => {
+    expect(normalizeImdbId('455')).toBeNull();
+    expect(normalizeImdbId('abc455590')).toBeNull();
+    expect(normalizeImdbId('45559078')).toBeNull();
+  });
+
+  it('normalizes a 4-digit numeric value into a valid IMDB id', () => {
+    expect(normalizeImdbId('1234')).toBe('tt0001234');
+  });
+
+  it('normalizes a 7-digit numeric value into a valid IMDB id', () => {
+    expect(normalizeImdbId('4500000')).toBe('tt4500000');
+  });
+
+  it('logs an error when a parsed row contains an invalid IMDB id', () => {
+    const logger = { error: vi.fn() };
+    const content = '2024-01-01;Example Movie;455;5';
+
+    const result = parseFilmtipsetRows(content, logger);
+
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual(['Line 1: invalid IMDB id']);
+    expect(logger.error).toHaveBeenCalledWith(
+      { line: 1, rawImdb: '455' },
+      'Invalid IMDB id value'
+    );
+  });
+});

--- a/packages/backend/src/movies/import-service.spec.ts
+++ b/packages/backend/src/movies/import-service.spec.ts
@@ -7,8 +7,19 @@ process.env.TMDB_API_KEY = 'test-tmdb-key';
 process.env.OMDB_API_KEY = 'test-omdb-key';
 process.env.JWT_SECRET = 'test-jwt-secret-with-at-least-32-chars!!';
 
+interface ParsedRow {
+  imdbId: string;
+  score: number;
+  watchedAt: Date;
+  title: string;
+  line: number;
+}
+
 let normalizeImdbId: (value: string) => string | null;
-let parseFilmtipsetRows: any;
+let parseFilmtipsetRows: (
+  content: string,
+  logger: { error: (...args: unknown[]) => void }
+) => { rows: ParsedRow[]; errors: string[] };
 
 beforeAll(async () => {
   const importService = await import('./import-service.js');

--- a/packages/backend/src/movies/import-service.spec.ts
+++ b/packages/backend/src/movies/import-service.spec.ts
@@ -18,8 +18,12 @@ interface ParsedRow {
 let normalizeImdbId: (value: string) => string | null;
 let parseFilmtipsetRows: (
   content: string,
-  logger: { error: (...args: unknown[]) => void }
+  logger: ImportLogger
 ) => { rows: ParsedRow[]; errors: string[] };
+
+interface ImportLogger {
+  error: (...args: unknown[]) => void;
+}
 
 beforeAll(async () => {
   const importService = await import('./import-service.js');
@@ -58,9 +62,6 @@ describe('import service helpers', () => {
 
     expect(result.rows).toEqual([]);
     expect(result.errors).toEqual(['Line 1: invalid IMDB id']);
-    expect(logger.error).toHaveBeenCalledWith(
-      { line: 1, rawImdb: '455' },
-      'Invalid IMDB id value'
-    );
+    expect(logger.error).toHaveBeenCalledWith({ line: 1, rawImdb: '455' }, 'Invalid IMDB id value');
   });
 });

--- a/packages/backend/src/movies/import-service.ts
+++ b/packages/backend/src/movies/import-service.ts
@@ -1,0 +1,166 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { parse } from 'csv-parse/sync';
+import { LOGGER } from '../registry.js';
+import { createMovieService } from './movie-service.js';
+import { createRatingService } from '../ratings/rating-service.js';
+import { createWatchService } from '../watch/watch-service.js';
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+export interface ImportSummary {
+  importedCount: number;
+  skippedCount: number;
+  errors: string[];
+}
+
+interface ParsedRow {
+  imdbId: string;
+  score: number;
+  watchedAt: Date;
+  title: string;
+  line: number;
+}
+
+export function normalizeImdbId(value: string): string | null {
+  const normalized = value.trim();
+
+  if (!/^[0-9]{4,7}$/.test(normalized)) {
+    return null;
+  }
+
+  return `tt${normalized.padStart(7, '0')}`;
+}
+
+export function parseFilmtipsetRows(
+  content: string,
+  logger: ServiceLogger
+): { rows: ParsedRow[]; errors: string[] } {
+  const records = parse(content, {
+    delimiter: ';',
+    trim: true,
+    skip_empty_lines: true,
+    relax_column_count: true,
+  });
+
+  if (records.length === 0) {
+    return { rows: [], errors: ['File content is empty'] };
+  }
+
+  const errors: string[] = [];
+  const rows: ParsedRow[] = [];
+  const header = records[0].map(column => column.toLowerCase());
+  const hasHeader =
+    header.includes('votedate') &&
+    header.includes('movietitle') &&
+    header.includes('imdb') &&
+    header.includes('score');
+
+  const startIndex = hasHeader ? 1 : 0;
+
+  for (let index = startIndex; index < records.length; index += 1) {
+    const rawLine = records[index];
+    const lineNumber = index + 1;
+
+    if (rawLine.length < 3 || rawLine.length > 4) {
+      errors.push(`Line ${lineNumber}: expected 3 or 4 columns, got ${rawLine.length}`);
+      continue;
+    }
+
+    let rawDate = '';
+    let title = '';
+    let imdbRaw = '';
+    let scoreRaw = '';
+
+    if (rawLine.length === 4) {
+      [rawDate, title, imdbRaw, scoreRaw] = rawLine;
+    } else {
+      const [dateAndTitle, imdb, score] = rawLine;
+      const [date, ...titleParts] = dateAndTitle.split(',');
+      rawDate = date?.trim() ?? '';
+      title = titleParts.join(',').trim();
+      imdbRaw = imdb;
+      scoreRaw = score;
+    }
+
+    const imdbId = normalizeImdbId(imdbRaw);
+    const score = Number(scoreRaw);
+    const watchedAt = new Date(rawDate);
+
+    if (!imdbId) {
+      logger.error({ line: lineNumber, rawImdb: imdbRaw }, 'Invalid IMDB id value');
+      errors.push(`Line ${lineNumber}: invalid IMDB id`);
+      continue;
+    }
+
+    if (!Number.isInteger(score) || score < 1 || score > 5) {
+      errors.push(`Line ${lineNumber}: score must be an integer between 1 and 5`);
+      continue;
+    }
+
+    if (Number.isNaN(watchedAt.getTime())) {
+      errors.push(`Line ${lineNumber}: invalid VoteDate`);
+      continue;
+    }
+
+    rows.push({ imdbId, score, watchedAt, title, line: lineNumber });
+  }
+
+  return { rows, errors };
+}
+
+export async function importRatingsFromFilmtipset(
+  userId: number,
+  content: string,
+  options?: ServiceOptions
+): Promise<ImportSummary> {
+  const serviceLogger = options?.logger ?? LOGGER;
+  const logger = serviceLogger.child({ module: 'import-service' });
+  const { rows, errors } = parseFilmtipsetRows(content, logger);
+
+  const movieService = createMovieService({ logger });
+  const ratingService = createRatingService({ logger });
+  const watchService = createWatchService({ logger });
+
+  const dedupedRows = new Map<string, ParsedRow>();
+  for (const row of rows) {
+    const existing = dedupedRows.get(row.imdbId);
+    if (!existing || row.watchedAt > existing.watchedAt) {
+      dedupedRows.set(row.imdbId, row);
+    }
+  }
+
+  let importedCount = 0;
+  let skippedCount = errors.length;
+
+  for (const row of dedupedRows.values()) {
+    try {
+      const lookupResult = await movieService.findMovieByImdbId(row.imdbId);
+      if (!lookupResult.success) {
+        errors.push(
+          `Line ${row.line}: ${lookupResult.message} (${lookupResult.reason}) for ${row.imdbId} (${row.title})`
+        );
+        skippedCount += 1;
+        continue;
+      }
+
+      await ratingService.upsertRating(lookupResult.tmdbId, userId, row.score);
+      await watchService.getOrCreateWatchEntry(lookupResult.tmdbId, userId, row.watchedAt);
+      importedCount += 1;
+    } catch (error) {
+      logger.error({ err: error, row }, 'Failed to import rating row');
+      errors.push(`Line ${row.line}: import failed`);
+      skippedCount += 1;
+    }
+  }
+
+  return {
+    importedCount,
+    skippedCount,
+    errors,
+  };
+}

--- a/packages/backend/src/movies/import-service.ts
+++ b/packages/backend/src/movies/import-service.ts
@@ -6,10 +6,12 @@ import { createMovieService } from './movie-service.js';
 import { createRatingService } from '../ratings/rating-service.js';
 import { createWatchService } from '../watch/watch-service.js';
 
-type ServiceLogger = Logger | FastifyBaseLogger;
+interface ImportLogger {
+  error: (...args: unknown[]) => void;
+}
 
 interface ServiceOptions {
-  logger?: ServiceLogger;
+  logger?: Logger | FastifyBaseLogger;
 }
 
 export interface ImportSummary {
@@ -38,7 +40,7 @@ export function normalizeImdbId(value: string): string | null {
 
 export function parseFilmtipsetRows(
   content: string,
-  logger: ServiceLogger
+  logger: ImportLogger
 ): { rows: ParsedRow[]; errors: string[] } {
   const records = parse(content, {
     delimiter: ';',

--- a/packages/backend/src/movies/import-service.ts
+++ b/packages/backend/src/movies/import-service.ts
@@ -71,10 +71,10 @@ export function parseFilmtipsetRows(
       continue;
     }
 
-    let rawDate = '';
-    let title = '';
-    let imdbRaw = '';
-    let scoreRaw = '';
+    let rawDate: string;
+    let title: string;
+    let imdbRaw: string;
+    let scoreRaw: string;
 
     if (rawLine.length === 4) {
       [rawDate, title, imdbRaw, scoreRaw] = rawLine;

--- a/packages/backend/src/movies/movie-routes.ts
+++ b/packages/backend/src/movies/movie-routes.ts
@@ -7,6 +7,7 @@ import { createUserDataService } from './user-data-service.js';
 import { createWatchService } from '../watch/watch-service.js';
 import { createRatingService } from '../ratings/rating-service.js';
 import { createReviewService } from '../reviews/review-service.js';
+import { importRatingsFromFilmtipset } from './import-service.js';
 import { USER_FILTER_VALUES } from './movie-types.js';
 import type { SortBy, UserFilterValue } from './movie-types.js';
 
@@ -36,6 +37,10 @@ const ratingBodySchema = z.object({
 
 const reviewBodySchema = z.object({
   content: z.string().min(1).max(5000),
+});
+
+const importBodySchema = z.object({
+  content: z.string().min(1),
 });
 
 function handleNotFound(error: unknown): never {
@@ -120,6 +125,15 @@ export const movieRoutes: FastifyPluginCallbackZod = (fastify, _options, done) =
         request.user.userId
       );
       return reply.send(data);
+    }
+  );
+
+  fastify.post(
+    '/import',
+    { preHandler: authenticate, schema: { body: importBodySchema } },
+    async (request, reply) => {
+      const summary = await importRatingsFromFilmtipset(request.user.userId, request.body.content);
+      return reply.send(summary);
     }
   );
 

--- a/packages/backend/src/movies/movie-service.spec.ts
+++ b/packages/backend/src/movies/movie-service.spec.ts
@@ -57,4 +57,26 @@ describe('movie service', () => {
     expect(loggedMeta).toEqual(expect.objectContaining({ imdbId: 'tt1234567' }));
     expect(loggedMeta.err).toBeInstanceOf(Error);
   });
+
+  it('returns a failed lookup result when TMDB returns TV results', async () => {
+    tmdbGetMock.mockReturnValue({
+      json: vi.fn().mockResolvedValue({
+        movie_results: [],
+        tv_results: [{ id: 42 }],
+        person_results: [],
+        tv_episode_results: [],
+        tv_season_results: [],
+      }),
+    });
+
+    const { createMovieService } = await import('./movie-service.js');
+    const movieService = createMovieService({ logger: loggerMock as unknown as Logger });
+    const result = await movieService.findMovieByImdbId('tt1234567');
+
+    expect(result).toEqual({
+      success: false,
+      reason: 'tv_results',
+      message: 'TMDB returned TV results instead of movie results',
+    });
+  });
 });

--- a/packages/backend/src/movies/movie-service.ts
+++ b/packages/backend/src/movies/movie-service.ts
@@ -24,6 +24,14 @@ interface ServiceOptions {
   logger?: ServiceLogger;
 }
 
+type FindMovieByImdbResult =
+  | { success: true; tmdbId: number }
+  | {
+      success: false;
+      reason: 'not_found' | 'tv_results';
+      message: string;
+    };
+
 export function createMovieService(options?: ServiceOptions) {
   const serviceLogger = options?.logger ?? LOGGER;
 
@@ -112,6 +120,52 @@ export function createMovieService(options?: ServiceOptions) {
     }
   }
 
+  async function findMovieByImdbId(imdbId: string): Promise<FindMovieByImdbResult> {
+    const logger = localLogger('findMovieByImdbId');
+
+    try {
+      const response = await tmdbClient
+        .get(`find/${imdbId}`, {
+          searchParams: { external_source: 'imdb_id' },
+        })
+        .json<{
+          movie_results: { id: number }[];
+          tv_results: unknown[];
+          person_results: unknown[];
+          tv_episode_results: unknown[];
+          tv_season_results: unknown[];
+        }>();
+
+      if (response.movie_results.length > 0) {
+        return { success: true, tmdbId: response.movie_results[0].id };
+      }
+
+      if (
+        response.tv_results.length > 0 ||
+        response.tv_episode_results.length > 0 ||
+        response.tv_season_results.length > 0
+      ) {
+        return {
+          success: false,
+          reason: 'tv_results',
+          message: 'TMDB returned TV results instead of movie results',
+        };
+      }
+
+      return {
+        success: false,
+        reason: 'not_found',
+        message: 'No TMDB movie result found for this IMDb ID',
+      };
+    } catch (error) {
+      logger.error({ imdbId, err: error }, 'TMDB lookup by IMDB id failed');
+      if (error instanceof HTTPError) {
+        throw new Error(`TMDB lookup failed: ${error.response.statusCode}`, { cause: error });
+      }
+      throw error;
+    }
+  }
+
   async function getMovieDetails(tmdbId: number): Promise<MovieDetail> {
     const logger = localLogger('getMovieDetails');
 
@@ -161,6 +215,7 @@ export function createMovieService(options?: ServiceOptions) {
     searchMovies,
     discoverMovies,
     getMovieById,
+    findMovieByImdbId,
     getMovieDetails,
   };
 }

--- a/packages/backend/src/movies/user-data-service.ts
+++ b/packages/backend/src/movies/user-data-service.ts
@@ -18,23 +18,23 @@ export function createUserDataService(options?: ServiceOptions) {
 
   async function fetchIdsForFilter(userId: number, filter: UserFilterValue): Promise<number[]> {
     if (filter === 'rated') {
-      const records = await prisma.rating.findMany({
+      const records = (await prisma.rating.findMany({
         where: { userId },
         select: { tmdbId: true },
-      });
+      })) as { tmdbId: number }[];
       return records.map(record => record.tmdbId);
     }
     if (filter === 'watched') {
-      const records = await prisma.watchEntry.findMany({
+      const records = (await prisma.watchEntry.findMany({
         where: { userId },
         select: { tmdbId: true },
-      });
+      })) as { tmdbId: number }[];
       return records.map(record => record.tmdbId);
     }
-    const records = await prisma.review.findMany({
+    const records = (await prisma.review.findMany({
       where: { userId },
       select: { tmdbId: true },
-    });
+    })) as { tmdbId: number }[];
     return records.map(record => record.tmdbId);
   }
 
@@ -48,11 +48,11 @@ export function createUserDataService(options?: ServiceOptions) {
       logger.debug({ userId, filters, sortBy }, 'Fetching filtered tmdb IDs');
 
       if (sortBy === 'watched_date') {
-        const entries = await prisma.watchEntry.findMany({
+        const entries = (await prisma.watchEntry.findMany({
           where: { userId },
           orderBy: [{ watchedAt: 'desc' }, { tmdbId: 'desc' }],
           select: { tmdbId: true },
-        });
+        })) as { tmdbId: number }[];
         const orderedIds = entries.map(entry => entry.tmdbId);
         const intersectionFilters = filters.filter(filter => filter !== 'watched');
         if (intersectionFilters.length === 0) return orderedIds;
@@ -64,11 +64,11 @@ export function createUserDataService(options?: ServiceOptions) {
       }
 
       if (sortBy === 'my_rating') {
-        const entries = await prisma.rating.findMany({
+        const entries = (await prisma.rating.findMany({
           where: { userId },
           orderBy: [{ score: 'desc' }, { tmdbId: 'desc' }],
           select: { tmdbId: true },
-        });
+        })) as { tmdbId: number }[];
         const orderedIds = entries.map(entry => entry.tmdbId);
         const intersectionFilters = filters.filter(filter => filter !== 'rated');
         if (intersectionFilters.length === 0) return orderedIds;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import Layout from '@/components/layout/Layout';
 import MoviesPage from '@/pages/movies/MoviesPage';
 import MovieDetailsPage from '@/pages/movie-details/MovieDetailsPage';
+import ProfilePage from '@/pages/profile/ProfilePage';
 import LoginPage from '@/pages/auth/LoginPage';
 import RegisterPage from '@/pages/auth/RegisterPage';
 
@@ -12,6 +13,7 @@ export default function App() {
         <Route index element={<Navigate to="/movies" replace />} />
         <Route path="movies" element={<MoviesPage />} />
         <Route path="movies/:tmdbId" element={<MovieDetailsPage />} />
+        <Route path="profile" element={<ProfilePage />} />
         <Route path="login" element={<LoginPage />} />
         <Route path="register" element={<RegisterPage />} />
       </Route>

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -23,10 +23,15 @@ export default function Header() {
         <nav className="flex items-center gap-2">
           {user ? (
             <>
-              <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
-                <User className="h-4 w-4" />
-                {user.username}
-              </span>
+              <Button variant="ghost" size="sm" asChild>
+                <Link
+                  to="/profile"
+                  className="flex items-center gap-1.5 text-sm text-muted-foreground"
+                >
+                  <User className="h-4 w-4" />
+                  {user.username}
+                </Link>
+              </Button>
               <Button variant="ghost" size="sm" onClick={() => void handleLogout()}>
                 <LogOut className="h-4 w-4" />
                 <span className="hidden sm:inline">Sign out</span>

--- a/packages/frontend/src/pages/profile/ProfilePage.tsx
+++ b/packages/frontend/src/pages/profile/ProfilePage.tsx
@@ -1,0 +1,145 @@
+import { type ChangeEvent, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/hooks/useAuth';
+import { importRatings, type ImportSummary } from '@/services/user-data-api';
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [content, setContent] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      setContent(text);
+      toast.success(`Loaded ${file.name}`);
+    } catch {
+      toast.error('Unable to read selected file');
+    }
+  };
+
+  const handleImport = async () => {
+    if (!content.trim()) {
+      toast.error('Please paste or select a file before importing.');
+      return;
+    }
+
+    setIsLoading(true);
+    setSummary(null);
+
+    try {
+      const result = await importRatings(content);
+      setSummary(result);
+      if (result.errors.length === 0) {
+        toast.success('Ratings imported successfully');
+      } else {
+        toast.success('Import completed with some skipped rows');
+      }
+    } catch (error) {
+      toast.error('Import failed. Check the file format and try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">Profile</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Sign in to import ratings</CardTitle>
+            <CardDescription>
+              Import functionality is available for signed in users only.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Please{' '}
+              <Link className="text-primary underline" to="/login">
+                sign in
+              </Link>{' '}
+              first.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight">Profile</h1>
+        <p className="text-muted-foreground">
+          Import movie ratings from filmtipset.se to your account.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Import ratings</CardTitle>
+          <CardDescription>
+            Paste your Filmtipset CSV content below or choose a file to load. The import will create
+            ratings and watched entries automatically.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="file">File upload</Label>
+            <Input
+              id="file"
+              type="file"
+              accept=".csv,text/csv,text/plain"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="content">Filmtipset CSV content</Label>
+            <Textarea
+              id="content"
+              value={content}
+              onChange={event => setContent(event.target.value)}
+              placeholder="Paste your Filmtipset export here"
+            />
+          </div>
+
+          <Button onClick={handleImport} disabled={isLoading}>
+            {isLoading ? 'Importing…' : 'Import ratings'}
+          </Button>
+
+          {summary ? (
+            <div className="rounded-lg border border-muted p-4">
+              <p className="font-semibold">Import summary</p>
+              <p>Imported: {summary.importedCount}</p>
+              <p>Skipped: {summary.skippedCount}</p>
+              {summary.errors.length > 0 && (
+                <div className="mt-4 space-y-2">
+                  <p className="font-semibold">Errors</p>
+                  <ul className="list-disc pl-5 text-sm text-muted-foreground">
+                    {summary.errors.map((message, index) => (
+                      <li key={index}>{message}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/profile/ProfilePage.tsx
+++ b/packages/frontend/src/pages/profile/ProfilePage.tsx
@@ -46,7 +46,7 @@ export default function ProfilePage() {
       } else {
         toast.success('Import completed with some skipped rows');
       }
-    } catch (error) {
+    } catch {
       toast.error('Import failed. Check the file format and try again.');
     } finally {
       setIsLoading(false);

--- a/packages/frontend/src/services/user-data-api.ts
+++ b/packages/frontend/src/services/user-data-api.ts
@@ -37,3 +37,16 @@ export async function updateReview(tmdbId: number, content: string): Promise<voi
 export async function removeReview(tmdbId: number): Promise<void> {
   await apiRequest(`/api/movies/${tmdbId}/review`, { method: 'DELETE' });
 }
+
+export interface ImportSummary {
+  importedCount: number;
+  skippedCount: number;
+  errors: string[];
+}
+
+export async function importRatings(content: string): Promise<ImportSummary> {
+  return apiRequest<ImportSummary>('/api/movies/import', {
+    method: 'POST',
+    body: JSON.stringify({ content }),
+  });
+}


### PR DESCRIPTION
This PR updates the Filmtipset import flow to return structured TMDB lookup results from `findMovieByImdbId()` and surface lookup failure reasons in import error messages.

Changes include:
- `findMovieByImdbId()` now returns `{ success, reason, message }`
- Import logic now records the failure reason for skipped rows
- Added backend tests for the lookup result shape and import parsing

Fixes #6.