### PR TITLE
feat: Filmtipset comments and importedAt #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ TMDB, IMDb, and Rotten Tomatoes ratings on each movie detail page.
 - Multi-user auth with JWT stored in httpOnly cookies
 - Mark movies as watched with a date
 - Rate movies 1–5 stars and write reviews
+- Import ratings or comments from Filmtipset CSV exports
 - Sort by popularity or rating
 
 ## Installation

--- a/packages/backend/prisma/migrations/20260427203416_add_imported_at_fields/migration.sql
+++ b/packages/backend/prisma/migrations/20260427203416_add_imported_at_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "importedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Rating" ADD COLUMN     "importedAt" TIMESTAMP(3);

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -46,25 +46,27 @@ model WatchEntry {
 }
 
 model Rating {
-  id        Int      @id @default(autoincrement())
-  tmdbId    Int
-  userId    Int
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  score     Int
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id         Int      @id @default(autoincrement())
+  tmdbId     Int
+  userId     Int
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  score      Int
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  importedAt DateTime?
 
   @@unique([tmdbId, userId])
 }
 
 model Comment {
-  id        Int      @id @default(autoincrement())
-  tmdbId    Int
-  userId    Int
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  content   String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id         Int      @id @default(autoincrement())
+  tmdbId     Int
+  userId     Int
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  content    String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  importedAt DateTime?
 
   @@index([tmdbId])
 }

--- a/packages/backend/src/comments/comment-service.spec.ts
+++ b/packages/backend/src/comments/comment-service.spec.ts
@@ -66,6 +66,58 @@ describe('comment service', () => {
     });
   });
 
+  it('creates a comment with an explicit createdAt date', async () => {
+    const createdAt = new Date('2024-01-01T12:00:00Z');
+    const comment = {
+      id: 12,
+      tmdbId: 123,
+      content: 'Great',
+      createdAt,
+      updatedAt: createdAt,
+      user: { id: 5, username: 'bob' },
+    };
+    createMock.mockResolvedValue(comment);
+
+    const { createCommentService } = await import('./comment-service.js');
+    const service = createCommentService({ logger: loggerMock });
+
+    expect(await service.createComment(123, 5, 'Great', createdAt)).toBe(comment);
+    expect(createMock).toHaveBeenCalledWith({
+      data: { tmdbId: 123, userId: 5, content: 'Great', createdAt },
+      include: { user: { select: { id: true, username: true } } },
+    });
+  });
+
+  it('creates a comment with an explicit importedAt date', async () => {
+    const createdAt = new Date('2024-01-01T12:00:00Z');
+    const importedAt = new Date('2024-06-01T12:00:00Z');
+    const comment = {
+      id: 13,
+      tmdbId: 123,
+      content: 'Imported',
+      createdAt,
+      updatedAt: createdAt,
+      importedAt,
+      user: { id: 5, username: 'bob' },
+    };
+    createMock.mockResolvedValue(comment);
+
+    const { createCommentService } = await import('./comment-service.js');
+    const service = createCommentService({ logger: loggerMock });
+
+    expect(await service.createComment(123, 5, 'Imported', createdAt, importedAt)).toBe(comment);
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        tmdbId: 123,
+        userId: 5,
+        content: 'Imported',
+        createdAt,
+        importedAt,
+      },
+      include: { user: { select: { id: true, username: true } } },
+    });
+  });
+
   it('throws when deleteComment does not delete any rows', async () => {
     deleteManyMock.mockResolvedValue({ count: 0 });
 

--- a/packages/backend/src/comments/comment-service.ts
+++ b/packages/backend/src/comments/comment-service.ts
@@ -34,15 +34,23 @@ export function createCommentService(options?: ServiceOptions) {
       });
     },
 
-    async createComment(tmdbId: number, userId: number, content: string) {
+    async createComment(
+      tmdbId: number,
+      userId: number,
+      content: string,
+      createdAt?: Date,
+      importedAt?: Date
+    ) {
       const logger = localLogger('createComment');
-      logger.debug({ tmdbId, userId }, 'Creating comment');
+      logger.debug({ tmdbId, userId, createdAt, importedAt }, 'Creating comment');
 
       return prisma.comment.create({
         data: {
           tmdbId,
           userId,
           content,
+          ...(createdAt ? { createdAt } : {}),
+          ...(importedAt ? { importedAt } : {}),
         },
         include: {
           user: {

--- a/packages/backend/src/movies/import-service.spec.ts
+++ b/packages/backend/src/movies/import-service.spec.ts
@@ -15,11 +15,23 @@ interface ParsedRow {
   line: number;
 }
 
+interface ParsedCommentRow {
+  imdbId: string;
+  watchedAt: Date;
+  title: string;
+  comment: string;
+  line: number;
+}
+
 let normalizeImdbId: (value: string) => string | null;
 let parseFilmtipsetRows: (
   content: string,
   logger: ImportLogger
 ) => { rows: ParsedRow[]; errors: string[] };
+let parseFilmtipsetCommentRows: (
+  content: string,
+  logger: ImportLogger
+) => { rows: ParsedCommentRow[]; errors: string[] };
 
 interface ImportLogger {
   error: (...args: unknown[]) => void;
@@ -29,6 +41,7 @@ beforeAll(async () => {
   const importService = await import('./import-service.js');
   normalizeImdbId = importService.normalizeImdbId;
   parseFilmtipsetRows = importService.parseFilmtipsetRows;
+  parseFilmtipsetCommentRows = importService.parseFilmtipsetCommentRows;
 });
 
 afterAll(() => {
@@ -63,5 +76,25 @@ describe('import service helpers', () => {
     expect(result.rows).toEqual([]);
     expect(result.errors).toEqual(['Line 1: invalid IMDB id']);
     expect(logger.error).toHaveBeenCalledWith({ line: 1, rawImdb: '455' }, 'Invalid IMDB id value');
+  });
+
+  it('parses Filmtipset comment rows with a header', () => {
+    const logger = { error: vi.fn() };
+    const content =
+      'Date;Movie;IMDB;Text\n2018-05-20;Captain Fantastic - En annorlunda pappa;3553976;"Tänkvärd film"';
+
+    const result = parseFilmtipsetCommentRows(content, logger);
+
+    expect(result.rows).toEqual([
+      {
+        imdbId: 'tt3553976',
+        title: 'Captain Fantastic - En annorlunda pappa',
+        watchedAt: new Date('2018-05-20'),
+        comment: 'Tänkvärd film',
+        line: 2,
+      },
+    ]);
+    expect(result.errors).toEqual([]);
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/movies/import-service.ts
+++ b/packages/backend/src/movies/import-service.ts
@@ -2,6 +2,7 @@ import type { FastifyBaseLogger } from 'fastify';
 import type { Logger } from 'pino';
 import { parse } from 'csv-parse/sync';
 import { LOGGER } from '../registry.js';
+import { createCommentService } from '../comments/comment-service.js';
 import { createMovieService } from './movie-service.js';
 import { createRatingService } from '../ratings/rating-service.js';
 import { createWatchService } from '../watch/watch-service.js';
@@ -20,11 +21,21 @@ export interface ImportSummary {
   errors: string[];
 }
 
-interface ParsedRow {
+export type FilmtipsetImportType = 'ratings' | 'comments';
+
+interface ParsedRatingRow {
   imdbId: string;
   score: number;
   watchedAt: Date;
   title: string;
+  line: number;
+}
+
+interface ParsedCommentRow {
+  imdbId: string;
+  watchedAt: Date;
+  title: string;
+  comment: string;
   line: number;
 }
 
@@ -41,7 +52,7 @@ export function normalizeImdbId(value: string): string | null {
 export function parseFilmtipsetRows(
   content: string,
   logger: ImportLogger
-): { rows: ParsedRow[]; errors: string[] } {
+): { rows: ParsedRatingRow[]; errors: string[] } {
   const records = parse(content, {
     delimiter: ';',
     trim: true,
@@ -54,8 +65,8 @@ export function parseFilmtipsetRows(
   }
 
   const errors: string[] = [];
-  const rows: ParsedRow[] = [];
-  const header = records[0].map(column => column.toLowerCase());
+  const rows: ParsedRatingRow[] = [];
+  const header = records[0].map(column => String(column).toLowerCase());
   const hasHeader =
     header.includes('votedate') &&
     header.includes('movietitle') &&
@@ -115,48 +126,153 @@ export function parseFilmtipsetRows(
   return { rows, errors };
 }
 
-export async function importRatingsFromFilmtipset(
-  userId: number,
+export function parseFilmtipsetCommentRows(
   content: string,
-  options?: ServiceOptions
-): Promise<ImportSummary> {
-  const serviceLogger = options?.logger ?? LOGGER;
-  const logger = serviceLogger.child({ module: 'import-service' });
-  const { rows, errors } = parseFilmtipsetRows(content, logger);
+  logger: ImportLogger
+): { rows: ParsedCommentRow[]; errors: string[] } {
+  const records = parse(content, {
+    delimiter: ';',
+    trim: true,
+    skip_empty_lines: true,
+    relax_column_count: true,
+  });
 
-  const movieService = createMovieService({ logger });
-  const ratingService = createRatingService({ logger });
-  const watchService = createWatchService({ logger });
+  if (records.length === 0) {
+    return { rows: [], errors: ['File content is empty'] };
+  }
 
-  const dedupedRows = new Map<string, ParsedRow>();
+  const errors: string[] = [];
+  const rows: ParsedCommentRow[] = [];
+  const header = records[0].map(column => String(column).toLowerCase());
+  const hasHeader =
+    header.includes('date') &&
+    header.includes('movie') &&
+    header.includes('imdb') &&
+    header.includes('text');
+
+  const startIndex = hasHeader ? 1 : 0;
+
+  for (let index = startIndex; index < records.length; index += 1) {
+    const rawLine = records[index];
+    const lineNumber = index + 1;
+
+    if (rawLine.length !== 4) {
+      errors.push(`Line ${lineNumber}: expected 4 columns, got ${rawLine.length}`);
+      continue;
+    }
+
+    const [rawDate, title, imdbRaw, commentRaw] = rawLine;
+    const imdbId = normalizeImdbId(imdbRaw);
+    const watchedAt = new Date(rawDate);
+    const comment = String(commentRaw ?? '').trim();
+
+    if (!imdbId) {
+      logger.error({ line: lineNumber, rawImdb: imdbRaw }, 'Invalid IMDB id value');
+      errors.push(`Line ${lineNumber}: invalid IMDB id`);
+      continue;
+    }
+
+    if (Number.isNaN(watchedAt.getTime())) {
+      errors.push(`Line ${lineNumber}: invalid Date`);
+      continue;
+    }
+
+    if (!comment) {
+      errors.push(`Line ${lineNumber}: comment text is required`);
+      continue;
+    }
+
+    rows.push({ imdbId, watchedAt, title, comment, line: lineNumber });
+  }
+
+  return { rows, errors };
+}
+
+function dedupeRowsByImdbId<T extends { imdbId: string; watchedAt: Date }>(rows: T[]) {
+  const dedupedRows = new Map<string, T>();
   for (const row of rows) {
     const existing = dedupedRows.get(row.imdbId);
     if (!existing || row.watchedAt > existing.watchedAt) {
       dedupedRows.set(row.imdbId, row);
     }
   }
+  return dedupedRows;
+}
 
+export async function importFromFilmtipset(
+  userId: number,
+  content: string,
+  type: FilmtipsetImportType,
+  options?: ServiceOptions
+): Promise<ImportSummary> {
+  const serviceLogger = options?.logger ?? LOGGER;
+  const logger = serviceLogger.child({ module: 'import-service' });
+  const movieService = createMovieService({ logger });
+  const watchService = createWatchService({ logger });
+  const importTimestamp = new Date();
+  const errors: string[] = [];
   let importedCount = 0;
-  let skippedCount = errors.length;
+  let skippedCount = 0;
 
-  for (const row of dedupedRows.values()) {
-    try {
-      const lookupResult = await movieService.findMovieByImdbId(row.imdbId);
-      if (!lookupResult.success) {
-        errors.push(
-          `Line ${row.line}: ${lookupResult.message} (${lookupResult.reason}) for ${row.imdbId} (${row.title})`
-        );
+  if (type === 'ratings') {
+    const parseResult = parseFilmtipsetRows(content, logger);
+    errors.push(...parseResult.errors);
+    skippedCount += parseResult.errors.length;
+    const dedupedRows = dedupeRowsByImdbId(parseResult.rows);
+    const ratingService = createRatingService({ logger });
+
+    for (const row of dedupedRows.values()) {
+      try {
+        const lookupResult = await movieService.findMovieByImdbId(row.imdbId);
+        if (!lookupResult.success) {
+          errors.push(
+            `Line ${row.line}: ${lookupResult.message} (${lookupResult.reason}) for ${row.imdbId} (${row.title})`
+          );
+          skippedCount += 1;
+          continue;
+        }
+
+        await ratingService.upsertRating(lookupResult.tmdbId, userId, row.score, importTimestamp);
+        await watchService.createWatchEntryIfMissing(lookupResult.tmdbId, userId, row.watchedAt);
+        importedCount += 1;
+      } catch (error) {
+        logger.error({ err: error, row }, 'Failed to import rating row');
+        errors.push(`Line ${row.line}: import failed`);
         skippedCount += 1;
-        continue;
       }
+    }
+  } else {
+    const parseResult = parseFilmtipsetCommentRows(content, logger);
+    errors.push(...parseResult.errors);
+    skippedCount += parseResult.errors.length;
+    const dedupedRows = dedupeRowsByImdbId(parseResult.rows);
+    const commentService = createCommentService({ logger });
 
-      await ratingService.upsertRating(lookupResult.tmdbId, userId, row.score);
-      await watchService.getOrCreateWatchEntry(lookupResult.tmdbId, userId, row.watchedAt);
-      importedCount += 1;
-    } catch (error) {
-      logger.error({ err: error, row }, 'Failed to import rating row');
-      errors.push(`Line ${row.line}: import failed`);
-      skippedCount += 1;
+    for (const row of dedupedRows.values()) {
+      try {
+        const lookupResult = await movieService.findMovieByImdbId(row.imdbId);
+        if (!lookupResult.success) {
+          errors.push(
+            `Line ${row.line}: ${lookupResult.message} (${lookupResult.reason}) for ${row.imdbId} (${row.title})`
+          );
+          skippedCount += 1;
+          continue;
+        }
+
+        await commentService.createComment(
+          lookupResult.tmdbId,
+          userId,
+          row.comment,
+          row.watchedAt,
+          importTimestamp
+        );
+        await watchService.createWatchEntryIfMissing(lookupResult.tmdbId, userId, row.watchedAt);
+        importedCount += 1;
+      } catch (error) {
+        logger.error({ err: error, row }, 'Failed to import comment row');
+        errors.push(`Line ${row.line}: import failed`);
+        skippedCount += 1;
+      }
     }
   }
 
@@ -165,4 +281,12 @@ export async function importRatingsFromFilmtipset(
     skippedCount,
     errors,
   };
+}
+
+export async function importRatingsFromFilmtipset(
+  userId: number,
+  content: string,
+  options?: ServiceOptions
+): Promise<ImportSummary> {
+  return importFromFilmtipset(userId, content, 'ratings', options);
 }

--- a/packages/backend/src/movies/movie-routes.ts
+++ b/packages/backend/src/movies/movie-routes.ts
@@ -8,7 +8,7 @@ import { createWatchService } from '../watch/watch-service.js';
 import { createRatingService } from '../ratings/rating-service.js';
 import { createReviewService } from '../reviews/review-service.js';
 import { createCommentService } from '../comments/comment-service.js';
-import { importRatingsFromFilmtipset } from './import-service.js';
+import { importFromFilmtipset } from './import-service.js';
 import { USER_FILTER_VALUES } from './movie-types.js';
 import type { SortBy, UserFilterValue } from './movie-types.js';
 
@@ -51,6 +51,7 @@ const deleteCommentParamsSchema = z.object({
 
 const importBodySchema = z.object({
   content: z.string().min(1),
+  type: z.enum(['ratings', 'comments']).default('ratings'),
 });
 
 function handleNotFound(error: unknown): never {
@@ -182,7 +183,11 @@ export const movieRoutes: FastifyPluginCallbackZod = (fastify, _options, done) =
     '/import',
     { preHandler: authenticate, schema: { body: importBodySchema } },
     async (request, reply) => {
-      const summary = await importRatingsFromFilmtipset(request.user.userId, request.body.content);
+      const summary = await importFromFilmtipset(
+        request.user.userId,
+        request.body.content,
+        request.body.type
+      );
       return reply.send(summary);
     }
   );

--- a/packages/backend/src/movies/movie-types.ts
+++ b/packages/backend/src/movies/movie-types.ts
@@ -74,5 +74,5 @@ export interface MovieDetail extends MovieListItem {
 
 export type SortBy = 'popularity' | 'rating' | 'watched_date' | 'my_rating';
 
-export const USER_FILTER_VALUES = ['rated', 'watched', 'reviewed'] as const;
+export const USER_FILTER_VALUES = ['rated', 'watched', 'reviewed', 'commented'] as const;
 export type UserFilterValue = (typeof USER_FILTER_VALUES)[number];

--- a/packages/backend/src/movies/user-data-service.spec.ts
+++ b/packages/backend/src/movies/user-data-service.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from 'pino';
+
+const loggerMock = {
+  child: vi.fn(() => loggerMock),
+  debug: vi.fn(),
+} as unknown as Logger;
+
+const ratingFindManyMock = vi.fn();
+const watchEntryFindManyMock = vi.fn();
+const reviewFindManyMock = vi.fn();
+const commentFindManyMock = vi.fn();
+
+vi.mock('../registry.js', () => ({ LOGGER: loggerMock }));
+vi.mock('../lib/prisma.js', () => ({
+  prisma: {
+    rating: { findMany: ratingFindManyMock },
+    watchEntry: { findMany: watchEntryFindManyMock },
+    review: { findMany: reviewFindManyMock },
+    comment: { findMany: commentFindManyMock },
+  },
+}));
+
+describe('user data service', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('returns TMDB ids for commented movies', async () => {
+    commentFindManyMock.mockResolvedValue([{ tmdbId: 42 }, { tmdbId: 99 }]);
+
+    const { createUserDataService } = await import('./user-data-service.js');
+    const service = createUserDataService({ logger: loggerMock });
+
+    const result = await service.getFilteredTmdbIds(5, ['commented']);
+
+    expect(result).toEqual([42, 99]);
+    expect(commentFindManyMock).toHaveBeenCalledWith({
+      where: { userId: 5 },
+      select: { tmdbId: true },
+    });
+  });
+
+  it('can intersect commented and watched filters when sorting by watched_date', async () => {
+    watchEntryFindManyMock.mockResolvedValue([{ tmdbId: 1 }, { tmdbId: 2 }]);
+    commentFindManyMock.mockResolvedValue([{ tmdbId: 1 }, { tmdbId: 3 }]);
+
+    const { createUserDataService } = await import('./user-data-service.js');
+    const service = createUserDataService({ logger: loggerMock });
+
+    const result = await service.getFilteredTmdbIds(5, ['watched', 'commented'], 'watched_date');
+
+    expect(result).toEqual([1]);
+  });
+});

--- a/packages/backend/src/movies/user-data-service.ts
+++ b/packages/backend/src/movies/user-data-service.ts
@@ -31,7 +31,15 @@ export function createUserDataService(options?: ServiceOptions) {
       })) as { tmdbId: number }[];
       return records.map(record => record.tmdbId);
     }
-    const records = (await prisma.review.findMany({
+    if (filter === 'reviewed') {
+      const records = (await prisma.review.findMany({
+        where: { userId },
+        select: { tmdbId: true },
+      })) as { tmdbId: number }[];
+      return records.map(record => record.tmdbId);
+    }
+
+    const records = (await prisma.comment.findMany({
       where: { userId },
       select: { tmdbId: true },
     })) as { tmdbId: number }[];

--- a/packages/backend/src/ratings/rating-service.spec.ts
+++ b/packages/backend/src/ratings/rating-service.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from 'pino';
+
+const loggerMock = {
+  child: vi.fn(() => loggerMock),
+  debug: vi.fn(),
+} as unknown as Logger;
+
+const upsertMock = vi.fn();
+const deleteManyMock = vi.fn();
+
+vi.mock('../registry.js', () => ({ LOGGER: loggerMock }));
+vi.mock('../lib/prisma.js', () => ({
+  prisma: {
+    rating: { upsert: upsertMock, deleteMany: deleteManyMock },
+  },
+}));
+
+describe('rating service', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('upserts a rating with importedAt on create', async () => {
+    const rating = { id: 1, tmdbId: 123, userId: 5, score: 4, importedAt: new Date() };
+    upsertMock.mockResolvedValue(rating);
+
+    const { createRatingService } = await import('./rating-service.js');
+    const service = createRatingService({ logger: loggerMock });
+    const importedAt = new Date('2024-06-01T12:00:00Z');
+
+    expect(await service.upsertRating(123, 5, 4, importedAt)).toBe(rating);
+    expect(upsertMock).toHaveBeenCalledWith({
+      where: { tmdbId_userId: { tmdbId: 123, userId: 5 } },
+      update: { score: 4 },
+      create: { tmdbId: 123, userId: 5, score: 4, importedAt },
+    });
+  });
+
+  it('upserts a rating without importedAt when called from UI', async () => {
+    const rating = { id: 2, tmdbId: 123, userId: 5, score: 5 };
+    upsertMock.mockResolvedValue(rating);
+
+    const { createRatingService } = await import('./rating-service.js');
+    const service = createRatingService({ logger: loggerMock });
+
+    expect(await service.upsertRating(123, 5, 5)).toBe(rating);
+    expect(upsertMock).toHaveBeenCalledWith({
+      where: { tmdbId_userId: { tmdbId: 123, userId: 5 } },
+      update: { score: 5 },
+      create: { tmdbId: 123, userId: 5, score: 5 },
+    });
+  });
+
+  it('deletes a rating', async () => {
+    deleteManyMock.mockResolvedValue({ count: 1 });
+
+    const { createRatingService } = await import('./rating-service.js');
+    const service = createRatingService({ logger: loggerMock });
+
+    await service.deleteRating(123, 5);
+    expect(deleteManyMock).toHaveBeenCalledWith({ where: { tmdbId: 123, userId: 5 } });
+  });
+});

--- a/packages/backend/src/ratings/rating-service.ts
+++ b/packages/backend/src/ratings/rating-service.ts
@@ -16,14 +16,19 @@ export function createRatingService(options?: ServiceOptions) {
     serviceLogger.child({ module: 'rating-service', context });
 
   return {
-    async upsertRating(tmdbId: number, userId: number, score: number) {
+    async upsertRating(tmdbId: number, userId: number, score: number, importedAt?: Date) {
       const logger = localLogger('upsertRating');
-      logger.debug({ tmdbId, userId, score }, 'Upserting rating');
+      logger.debug({ tmdbId, userId, score, importedAt }, 'Upserting rating');
 
       return prisma.rating.upsert({
         where: { tmdbId_userId: { tmdbId, userId } },
         update: { score },
-        create: { tmdbId, userId, score },
+        create: {
+          tmdbId,
+          userId,
+          score,
+          ...(importedAt ? { importedAt } : {}),
+        },
       });
     },
 

--- a/packages/backend/src/watch/watch-service.spec.ts
+++ b/packages/backend/src/watch/watch-service.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from 'pino';
+
+const loggerMock = {
+  child: vi.fn(() => loggerMock),
+  debug: vi.fn(),
+} as unknown as Logger;
+
+const findUniqueMock = vi.fn();
+const createMock = vi.fn();
+
+vi.mock('../registry.js', () => ({ LOGGER: loggerMock }));
+vi.mock('../lib/prisma.js', () => ({
+  prisma: {
+    watchEntry: { findUnique: findUniqueMock, create: createMock },
+  },
+}));
+
+describe('watch service', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('returns an existing watch entry instead of updating it', async () => {
+    const existingEntry = { tmdbId: 12, userId: 34, watchedAt: new Date('2023-01-01') };
+    findUniqueMock.mockResolvedValue(existingEntry);
+
+    const { createWatchService } = await import('./watch-service.js');
+    const service = createWatchService({ logger: loggerMock });
+
+    const result = await service.createWatchEntryIfMissing(12, 34, new Date('2024-01-01'));
+
+    expect(result).toBe(existingEntry);
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { tmdbId_userId: { tmdbId: 12, userId: 34 } },
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('creates a new watch entry when none exists', async () => {
+    findUniqueMock.mockResolvedValue(null);
+    const createdEntry = { tmdbId: 12, userId: 34, watchedAt: new Date('2024-01-01') };
+    createMock.mockResolvedValue(createdEntry);
+
+    const { createWatchService } = await import('./watch-service.js');
+    const service = createWatchService({ logger: loggerMock });
+
+    const result = await service.createWatchEntryIfMissing(12, 34, new Date('2024-01-01'));
+
+    expect(result).toBe(createdEntry);
+    expect(createMock).toHaveBeenCalledWith({
+      data: { tmdbId: 12, userId: 34, watchedAt: new Date('2024-01-01') },
+    });
+  });
+});

--- a/packages/backend/src/watch/watch-service.ts
+++ b/packages/backend/src/watch/watch-service.ts
@@ -27,6 +27,21 @@ export function createWatchService(options?: ServiceOptions) {
       });
     },
 
+    async createWatchEntryIfMissing(tmdbId: number, userId: number, watchedAt: Date) {
+      const logger = localLogger('createWatchEntryIfMissing');
+      logger.debug({ tmdbId, userId, watchedAt }, 'Creating watch entry only if missing');
+
+      const existing = await prisma.watchEntry.findUnique({
+        where: { tmdbId_userId: { tmdbId, userId } },
+      });
+
+      if (existing) return existing;
+
+      return prisma.watchEntry.create({
+        data: { tmdbId, userId, watchedAt },
+      });
+    },
+
     async deleteWatchEntry(tmdbId: number, userId: number) {
       const logger = localLogger('deleteWatchEntry');
       logger.debug({ tmdbId, userId }, 'Deleting watch entry');

--- a/packages/frontend/src/components/movies/MovieSearch.tsx
+++ b/packages/frontend/src/components/movies/MovieSearch.tsx
@@ -15,6 +15,7 @@ const USER_FILTER_LABELS: Record<UserFilter, string> = {
   rated: 'Rated by me',
   watched: 'Watched by me',
   reviewed: 'Reviewed by me',
+  commented: 'Commented by me',
 };
 
 interface MovieSearchProps {

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatDateTime(value: string | Date | number): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const pad = (num: number) => String(num).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}`;
+}

--- a/packages/frontend/src/pages/movie-details/MovieDetailsPage.tsx
+++ b/packages/frontend/src/pages/movie-details/MovieDetailsPage.tsx
@@ -11,6 +11,7 @@ import { useMovieDetails } from '@/hooks/useMovieDetails';
 import { useMovieComments } from '@/hooks/useMovieComments';
 import { useUserMovieData } from '@/hooks/useUserMovieData';
 import { useAuth } from '@/hooks/useAuth';
+import { formatDateTime } from '@/lib/utils';
 
 export default function MovieDetailsPage() {
   const { tmdbId } = useParams<{ tmdbId: string }>();
@@ -215,12 +216,7 @@ export default function MovieDetailsPage() {
             </Button>
             {isWatched && userData?.watchEntry?.watchedAt && (
               <span className="text-sm text-muted-foreground">
-                on{' '}
-                {new Date(userData.watchEntry.watchedAt).toLocaleDateString(undefined, {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
+                on {formatDateTime(userData.watchEntry.watchedAt)}
               </span>
             )}
           </div>
@@ -342,7 +338,7 @@ export default function MovieDetailsPage() {
                   <div>
                     <p className="text-sm font-semibold">{comment.user.username}</p>
                     <p className="text-xs text-muted-foreground">
-                      {new Date(comment.createdAt).toLocaleString()}
+                      {formatDateTime(comment.createdAt)}
                     </p>
                   </div>
                   {user?.id === comment.user.id && (

--- a/packages/frontend/src/pages/profile/ProfilePage.tsx
+++ b/packages/frontend/src/pages/profile/ProfilePage.tsx
@@ -5,14 +5,22 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/hooks/useAuth';
-import { importRatings, type ImportSummary } from '@/services/user-data-api';
+import { importFilmtipset, type ImportSummary } from '@/services/user-data-api';
 
 export default function ProfilePage() {
   const { user } = useAuth();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [content, setContent] = useState('');
+  const [importType, setImportType] = useState<'ratings' | 'comments'>('ratings');
   const [isLoading, setIsLoading] = useState(false);
   const [summary, setSummary] = useState<ImportSummary | null>(null);
 
@@ -39,10 +47,10 @@ export default function ProfilePage() {
     setSummary(null);
 
     try {
-      const result = await importRatings(content);
+      const result = await importFilmtipset(content, importType);
       setSummary(result);
       if (result.errors.length === 0) {
-        toast.success('Ratings imported successfully');
+        toast.success(`${importType === 'ratings' ? 'Ratings' : 'Comments'} imported successfully`);
       } else {
         toast.success('Import completed with some skipped rows');
       }
@@ -83,19 +91,34 @@ export default function ProfilePage() {
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight">Profile</h1>
         <p className="text-muted-foreground">
-          Import movie ratings from filmtipset.se to your account.
+          Import movie ratings or comments from filmtipset.se to your account.
         </p>
       </div>
 
       <Card>
         <CardHeader>
-          <CardTitle>Import ratings</CardTitle>
+          <CardTitle>Import Filmtipset export</CardTitle>
           <CardDescription>
             Paste your Filmtipset CSV content below or choose a file to load. The import will create
-            ratings and watched entries automatically.
+            ratings, comments, and watched entries automatically.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="importType">Import type</Label>
+            <Select
+              value={importType}
+              onValueChange={value => setImportType(value as 'ratings' | 'comments')}>
+              <SelectTrigger id="importType">
+                <SelectValue placeholder="Select import type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ratings">Ratings</SelectItem>
+                <SelectItem value="comments">Comments</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
           <div className="grid gap-2">
             <Label htmlFor="file">File upload</Label>
             <Input
@@ -118,7 +141,9 @@ export default function ProfilePage() {
           </div>
 
           <Button onClick={handleImport} disabled={isLoading}>
-            {isLoading ? 'Importing…' : 'Import ratings'}
+            {isLoading
+              ? 'Importing…'
+              : `Import ${importType === 'ratings' ? 'ratings' : 'comments'}`}
           </Button>
 
           {summary ? (

--- a/packages/frontend/src/services/user-data-api.ts
+++ b/packages/frontend/src/services/user-data-api.ts
@@ -44,9 +44,16 @@ export interface ImportSummary {
   errors: string[];
 }
 
-export async function importRatings(content: string): Promise<ImportSummary> {
+export async function importFilmtipset(
+  content: string,
+  type: 'ratings' | 'comments'
+): Promise<ImportSummary> {
   return apiRequest<ImportSummary>('/api/movies/import', {
     method: 'POST',
-    body: JSON.stringify({ content }),
+    body: JSON.stringify({ content, type }),
   });
+}
+
+export async function importRatings(content: string): Promise<ImportSummary> {
+  return importFilmtipset(content, 'ratings');
 }

--- a/packages/frontend/src/types/movie.ts
+++ b/packages/frontend/src/types/movie.ts
@@ -52,4 +52,4 @@ export interface UserMovieData {
 
 export type SortBy = 'popularity' | 'rating' | 'watched_date' | 'my_rating';
 
-export type UserFilter = 'rated' | 'watched' | 'reviewed';
+export type UserFilter = 'rated' | 'watched' | 'reviewed' | 'commented';


### PR DESCRIPTION
Adds Filmtipset ratings and comments import support, tracks importedAt for imported ratings/comments, and includes Prisma migration for the new fields.

Includes frontend UI support for selecting import type, comment timestamp formatting, and backend filters for commented movies.