### PR TITLE
feat: add tv shows #14

### DIFF
--- a/.github/prompts/plan-velaraTvTracker.prompt.md
+++ b/.github/prompts/plan-velaraTvTracker.prompt.md
@@ -1,0 +1,318 @@
+# Plan: Introduce TV Shows
+
+## TL;DR
+
+Add full TV show support as a parallel domain alongside movies. New dedicated DB tables (no
+collision with movie tables), TMDB+OMDB data, episode-level watch tracking, season+show-level
+ratings, reviews and comments at show level. Separate /tv frontend routes. Extend Trakt import for
+TV.
+
+---
+
+## Decisions
+
+- **Tracking granularity**: Episode-level watch tracking; season + show-level ratings; reviews +
+  comments at show level
+- **External data**: TMDB (primary) + OMDB (external ratings enrichment) — same pattern as movies
+- **UI**: Separate `/tv` and `/tv/:seriesId` routes, separate pages/components
+- **DB strategy**: New dedicated TV tables (no modifying existing movie tables) to avoid tmdbId
+  namespace collision
+- **Trakt import**: Extended to import TV show ratings and episode watch history
+- **TvRating**: Use `seasonNumber = 0` as convention for show-level rating; non-nullable with unique
+  `[seriesTmdbId, seasonNumber, userId]`
+
+---
+
+## Phase 1: Database Schema
+
+Add 4 new Prisma models in `packages/backend/prisma/schema.prisma`:
+
+1. **TvWatchEntry** — tracks individual episodes watched
+   - `id`, `seriesTmdbId: String`, `seasonNumber: Int`, `episodeNumber: Int`, `userId`, `watchedAt`,
+     `source`, `createdAt`
+   - Unique: `[seriesTmdbId, seasonNumber, episodeNumber, userId]`
+   - Cascade delete on User
+
+2. **TvRating** — show-level (seasonNumber=0) or season-level rating
+   - `id`, `seriesTmdbId: String`, `seasonNumber: Int (default 0)`, `userId`, `score: Int`,
+     `source`, `ratedAt`, `createdAt`, `updatedAt`, `importedAt?`
+   - Unique: `[seriesTmdbId, seasonNumber, userId]`
+   - Cascade delete on User
+
+3. **TvReview** — show-level review
+   - `id`, `seriesTmdbId: String`, `userId`, `content: String`, `createdAt`, `updatedAt`
+   - Unique: `[seriesTmdbId, userId]`
+   - Cascade delete on User
+
+4. **TvComment** — show-level comments
+   - `id`, `seriesTmdbId: String`, `userId`, `content: String`, `createdAt`, `updatedAt`,
+     `importedAt?`
+   - Index on `seriesTmdbId`
+   - Cascade delete on User
+
+After schema changes: `cd packages/backend && npm run db:generate` +
+`npx prisma migrate dev --name add_tv_shows`
+
+---
+
+## Phase 2: Backend — TV Show Service Layer
+
+New folder: `packages/backend/src/tv-shows/`
+
+### tv-show-types.ts
+
+- `TvShowListItem` — seriesTmdbId, name, posterPath, backdropPath, voteAverage, voteCount,
+  firstAirDate, overview
+- `TvShowDetail` — extends TvShowListItem + genres, number_of_seasons, number_of_episodes,
+  externalRatings, status, networks, imdbId, urls
+- `TvSeason` — seasonNumber, name, episodeCount, airDate, posterPath, episodes[]
+- `TvEpisode` — episodeNumber, name, overview, airDate, runtime, stillPath
+- `UserTvData` — watchEntries: TvWatchEntry[], showRating?, seasonRatings: Record<number, TvRating>,
+  review?
+
+### tv-show-service.ts
+
+Analogous to `movie-service.ts`:
+
+- `searchTvShows(query, page)` — TMDB `/search/tv`
+- `discoverTvShows(sortBy, page)` — TMDB `/discover/tv`
+- `getTvShowById(seriesTmdbId)` — TMDB `/tv/{id}` with external_ids appended
+- `getTvShowDetails(seriesTmdbId)` — Full details + OMDB enrichment via IMDb ID (same pattern as
+  `getMovieDetails`)
+- `getTvSeason(seriesTmdbId, seasonNumber)` — TMDB `/tv/{id}/season/{n}` with episode list
+- `mapTvListItem()` — transform TMDB result to TvShowListItem
+
+### tv-watch-service.ts
+
+- `markEpisodeWatched(seriesTmdbId, seasonNumber, episodeNumber, userId, watchedAt, source)` —
+  upsert
+- `unmarkEpisodeWatched(seriesTmdbId, seasonNumber, episodeNumber, userId)` — delete
+- `getWatchEntriesForSeries(seriesTmdbId, userId)` — all episodes watched for a series
+- `createWatchEntryIfMissing(...)` — for import deduplication
+
+### tv-rating-service.ts
+
+- `upsertTvRating(seriesTmdbId, seasonNumber=0, userId, score, ratedAt?, importedAt?, source)` —
+  upsert
+- `deleteTvRating(seriesTmdbId, seasonNumber, userId)` — delete
+- `getTvRatingsForSeries(seriesTmdbId, userId)` — all ratings for a series (show + seasons)
+
+### tv-review-service.ts
+
+- `upsertTvReview(seriesTmdbId, userId, content)` — upsert
+- `deleteTvReview(seriesTmdbId, userId)` — delete
+
+### tv-comment-service.ts
+
+- `getCommentsForSeries(seriesTmdbId)` — ordered by newest first, include user metadata
+- `createComment(seriesTmdbId, userId, content, createdAt?, importedAt?)` — create
+- `deleteComment(seriesTmdbId, commentId, userId)` — delete (validates ownership)
+
+### tv-user-data-service.ts
+
+- `getFilteredSeriesTmdbIds(userId, filters, sortBy?)` — same pattern as `getFilteredTmdbIds` in
+  movie domain; queries TvRating, TvWatchEntry, TvReview, TvComment
+- `getUserTvData(seriesTmdbId, userId)` — aggregated user data for a series
+
+### tv-show-routes.ts
+
+Routes under `/api/tv`:
+
+| Method | Endpoint                                 | Auth     | Purpose                                                                 |
+| ------ | ---------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| GET    | `/`                                      | —        | List/search TV shows (search, page, sort_by, user_filter)               |
+| GET    | `/:seriesId`                             | —        | TV show details                                                         |
+| GET    | `/:seriesId/season/:seasonNumber`        | optional | Season details + episode list                                           |
+| GET    | `/:seriesId/user-data`                   | ✓        | User's ratings, review, watch entries                                   |
+| GET    | `/:seriesId/comments`                    | —        | All show comments                                                       |
+| POST   | `/:seriesId/comments`                    | ✓        | Create comment                                                          |
+| DELETE | `/:seriesId/comments/:commentId`         | ✓        | Delete comment                                                          |
+| PUT    | `/:seriesId/rating`                      | ✓        | Set show-level rating (seasonNumber=0)                                  |
+| DELETE | `/:seriesId/rating`                      | ✓        | Remove show-level rating                                                |
+| PUT    | `/:seriesId/season/:seasonNumber/rating` | ✓        | Set season rating                                                       |
+| DELETE | `/:seriesId/season/:seasonNumber/rating` | ✓        | Remove season rating                                                    |
+| PUT    | `/:seriesId/review`                      | ✓        | Create/update review                                                    |
+| DELETE | `/:seriesId/review`                      | ✓        | Delete review                                                           |
+| PUT    | `/:seriesId/watch`                       | ✓        | Mark episode watched: body `{ seasonNumber, episodeNumber, watchedAt }` |
+| DELETE | `/:seriesId/watch`                       | ✓        | Unmark episode: body `{ seasonNumber, episodeNumber }`                  |
+
+---
+
+## Phase 3: Extend Trakt Import
+
+Update `packages/backend/src/movies/import-service.ts`:
+
+- In `importFromTrakt()`, add processing for:
+  - `traktExport.ratings` entries where `type === 'show'` → upsert TvRating (seasonNumber=0) using
+    `show.ids.tmdb`
+  - `traktExport.history` entries where `type === 'episode'` → create TvWatchEntry using
+    `show.ids.tmdb` + `episode.season` + `episode.number`
+- Add `resolveTraktTvSeriesTmdbId(show)` helper — uses `show.ids.tmdb` directly (no IMDb lookup
+  needed since Trakt provides TMDB IDs for TV)
+- Update `TraktExport` type in `trakt.types.ts` to include TV-specific fields if not already present
+
+---
+
+## Phase 4: Register TV Routes
+
+Update `packages/backend/src/index.ts`:
+
+- Import `tvRoutes` from `tv-shows/tv-show-routes.ts`
+- Register: `app.register(tvRoutes, { prefix: '/api/tv' })`
+
+---
+
+## Phase 5: Frontend — Types & Services
+
+### types/tv-show.ts (new)
+
+- `TvShowListItem`, `TvShowDetail`, `TvSeason`, `TvEpisode`
+- `UserTvData` — showRating?, seasonRatings, watchedEpisodes: Set of "s{n}e{n}" keys, review?
+- `TvSortBy` — 'popularity' | 'rating' | 'watched_date' | 'my_rating'
+- `TvUserFilter` — 'rated' | 'watched' | 'reviewed' | 'commented'
+
+### services/tv-shows-api.ts (new)
+
+- `fetchTvShows(params)` — search, page, sort, filter
+- `fetchTvShowDetail(seriesId)` — full show details
+- `fetchTvSeason(seriesId, seasonNumber)` — season + episodes
+
+### services/user-tv-data-api.ts (new)
+
+- `fetchUserTvData(seriesId)` — get user data for show
+- `updateTvRating(seriesId, score)` / `removeTvRating(seriesId)` — show-level
+- `updateTvSeasonRating(seriesId, seasonNumber, score)` /
+  `removeTvSeasonRating(seriesId, seasonNumber)` — season-level
+- `updateTvReview(seriesId, content)` / `removeTvReview(seriesId)`
+- `markEpisodeWatched(seriesId, seasonNumber, episodeNumber, watchedAt)` /
+  `unmarkEpisodeWatched(...)`
+
+### services/tv-comments-api.ts (new)
+
+- `fetchTvComments(seriesId)` / `createTvComment(seriesId, content)` /
+  `deleteTvComment(seriesId, commentId)`
+
+---
+
+## Phase 6: Frontend Hooks
+
+- `hooks/useTvShows.ts` — React Query wrapper for `fetchTvShows`, cache key `['tv-shows', params]`,
+  5-min stale
+- `hooks/useTvShowDetails.ts` — dual queries: show details (10-min cache) + user data (0 stale,
+  auth-gated)
+- `hooks/useTvSeason.ts` — season details query, cache key `['tv-season', seriesId, seasonNumber]`
+- `hooks/useUserTvData.ts` — mutations for all ratings/review/watch actions with toast feedback +
+  cache invalidation
+- `hooks/useTvComments.ts` — comments query + add/remove mutations
+
+---
+
+## Phase 7: Frontend Components
+
+New folder: `packages/frontend/src/components/tv-shows/`
+
+- `TvShowCard.tsx` — mirrors MovieCard; shows poster, name, year, TMDB rating; links to
+  `/tv/:seriesId`
+- `TvShowGrid.tsx` — mirrors MovieGrid; responsive grid, skeleton loading
+- `EpisodeRow.tsx` — episode number, name, air date, runtime, watch toggle button; shows "watched"
+  state
+- `SeasonSection.tsx` — collapsible season header (poster, name, episode count, season rating
+  stars), renders EpisodeRow list
+
+---
+
+## Phase 8: Frontend Pages
+
+### pages/tv-shows/TvShowsPage.tsx (new)
+
+- Mirrors MoviesPage: search, sort, filter, pagination
+- Uses TvShowGrid + TvShowCard
+- Separate sort options: popularity, rating (no watched_date/my_rating unless filter active)
+
+### pages/tv-show-details/TvShowDetailsPage.tsx (new)
+
+- Hero section: backdrop, poster, title, status, genres, first air date, network
+- External ratings badges (TMDB, IMDB, RT) — same pattern as MovieDetailsPage
+- Show-level: watch (overall progress info), rating (StarRating), review textarea
+- Comments section — same as movie details
+- Seasons list: SeasonSection components with EpisodeRow children
+  - Season-level star rating
+  - Episode-level watch toggles
+
+---
+
+## Phase 9: Routing & Navigation
+
+- Update `packages/frontend/src/App.tsx`: add routes `/tv` → TvShowsPage and `/tv/:seriesId` →
+  TvShowDetailsPage
+- Update `packages/frontend/src/components/layout/Header.tsx`: add "TV Shows" nav link alongside
+  "Movies"
+
+---
+
+## Relevant Files (to create or modify)
+
+**Create (Backend):**
+
+- `packages/backend/src/tv-shows/tv-show-types.ts`
+- `packages/backend/src/tv-shows/tv-show-service.ts`
+- `packages/backend/src/tv-shows/tv-watch-service.ts`
+- `packages/backend/src/tv-shows/tv-rating-service.ts`
+- `packages/backend/src/tv-shows/tv-review-service.ts`
+- `packages/backend/src/tv-shows/tv-comment-service.ts`
+- `packages/backend/src/tv-shows/tv-user-data-service.ts`
+- `packages/backend/src/tv-shows/tv-show-routes.ts`
+
+**Modify (Backend):**
+
+- `packages/backend/prisma/schema.prisma` — add 4 new models
+- `packages/backend/src/movies/import-service.ts` — extend Trakt importer for TV
+- `packages/backend/src/trakt.types.ts` — add TV-specific Trakt export types if missing
+- `packages/backend/src/index.ts` — register TV routes
+
+**Create (Frontend):**
+
+- `packages/frontend/src/types/tv-show.ts`
+- `packages/frontend/src/services/tv-shows-api.ts`
+- `packages/frontend/src/services/user-tv-data-api.ts`
+- `packages/frontend/src/services/tv-comments-api.ts`
+- `packages/frontend/src/hooks/useTvShows.ts`
+- `packages/frontend/src/hooks/useTvShowDetails.ts`
+- `packages/frontend/src/hooks/useTvSeason.ts`
+- `packages/frontend/src/hooks/useUserTvData.ts`
+- `packages/frontend/src/hooks/useTvComments.ts`
+- `packages/frontend/src/components/tv-shows/TvShowCard.tsx`
+- `packages/frontend/src/components/tv-shows/TvShowGrid.tsx`
+- `packages/frontend/src/components/tv-shows/EpisodeRow.tsx`
+- `packages/frontend/src/components/tv-shows/SeasonSection.tsx`
+- `packages/frontend/src/pages/tv-shows/TvShowsPage.tsx`
+- `packages/frontend/src/pages/tv-show-details/TvShowDetailsPage.tsx`
+
+**Modify (Frontend):**
+
+- `packages/frontend/src/App.tsx` — add `/tv` and `/tv/:seriesId` routes
+- `packages/frontend/src/components/layout/Header.tsx` — add TV Shows nav link
+
+---
+
+## Verification
+
+1. `cd packages/backend && npx prisma migrate dev --name add_tv_shows` — apply new schema
+2. `cd packages/backend && npm run db:generate` — regenerate Prisma client
+3. `npm run build` from workspace root — verify TypeScript compilation across both packages
+4. `npm run lint` — verify no lint errors
+5. `npm test` — ensure existing movie tests still pass
+6. Manual: search for a TV show (e.g., "Breaking Bad"), view detail page, mark episodes as watched,
+   set a season rating, leave a comment
+7. Manual: import a Trakt export that includes TV show ratings and episode history, verify data
+   appears correctly
+
+---
+
+## Explicitly Out of Scope
+
+- Per-episode ratings (only show + season level)
+- Reviews/comments at season or episode level (show level only)
+- Filmtipset import for TV (Filmtipset is a movie-only site)
+- Push notifications for new episodes
+- "Continue watching" / progress tracking UI

--- a/packages/backend/prisma/migrations/20260503152528_add_tv_shows/migration.sql
+++ b/packages/backend/prisma/migrations/20260503152528_add_tv_shows/migration.sql
@@ -1,0 +1,78 @@
+-- CreateTable
+CREATE TABLE "TvWatchEntry" (
+    "id" SERIAL NOT NULL,
+    "seriesTmdbId" TEXT NOT NULL,
+    "seasonNumber" INTEGER NOT NULL,
+    "episodeNumber" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "watchedAt" TIMESTAMP(3) NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TvWatchEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TvRating" (
+    "id" SERIAL NOT NULL,
+    "seriesTmdbId" TEXT NOT NULL,
+    "seasonNumber" INTEGER NOT NULL DEFAULT 0,
+    "userId" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "ratedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "importedAt" TIMESTAMP(3),
+
+    CONSTRAINT "TvRating_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TvReview" (
+    "id" SERIAL NOT NULL,
+    "seriesTmdbId" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TvReview_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TvComment" (
+    "id" SERIAL NOT NULL,
+    "seriesTmdbId" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "importedAt" TIMESTAMP(3),
+
+    CONSTRAINT "TvComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TvWatchEntry_seriesTmdbId_seasonNumber_episodeNumber_userId_key" ON "TvWatchEntry"("seriesTmdbId", "seasonNumber", "episodeNumber", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TvRating_seriesTmdbId_seasonNumber_userId_key" ON "TvRating"("seriesTmdbId", "seasonNumber", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TvReview_seriesTmdbId_userId_key" ON "TvReview"("seriesTmdbId", "userId");
+
+-- CreateIndex
+CREATE INDEX "TvComment_seriesTmdbId_idx" ON "TvComment"("seriesTmdbId");
+
+-- AddForeignKey
+ALTER TABLE "TvWatchEntry" ADD CONSTRAINT "TvWatchEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TvRating" ADD CONSTRAINT "TvRating_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TvReview" ADD CONSTRAINT "TvReview_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TvComment" ADD CONSTRAINT "TvComment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -11,15 +11,19 @@ datasource db {
 }
 
 model User {
-  id           Int          @id @default(autoincrement())
-  email        String       @unique
-  username     String       @unique
-  passwordHash String
-  createdAt    DateTime     @default(now())
-  reviews      Review[]
-  comments     Comment[]
-  watchEntries WatchEntry[]
-  ratings      Rating[]
+  id             Int            @id @default(autoincrement())
+  email          String         @unique
+  username       String         @unique
+  passwordHash   String
+  createdAt      DateTime       @default(now())
+  reviews        Review[]
+  comments       Comment[]
+  watchEntries   WatchEntry[]
+  ratings        Rating[]
+  tvWatchEntries TvWatchEntry[]
+  tvRatings      TvRating[]
+  tvReviews      TvReview[]
+  tvComments     TvComment[]
 }
 
 model Review {
@@ -72,4 +76,59 @@ model Comment {
   importedAt DateTime?
 
   @@index([tmdbId])
+}
+
+model TvWatchEntry {
+  id            Int      @id @default(autoincrement())
+  seriesTmdbId  String
+  seasonNumber  Int
+  episodeNumber Int
+  userId        Int
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  watchedAt     DateTime
+  source        String   @default("manual")
+  createdAt     DateTime @default(now())
+
+  @@unique([seriesTmdbId, seasonNumber, episodeNumber, userId])
+}
+
+model TvRating {
+  id           Int       @id @default(autoincrement())
+  seriesTmdbId String
+  seasonNumber Int       @default(0)
+  userId       Int
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  score        Int
+  source       String    @default("manual")
+  ratedAt      DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+  importedAt   DateTime?
+
+  @@unique([seriesTmdbId, seasonNumber, userId])
+}
+
+model TvReview {
+  id           Int      @id @default(autoincrement())
+  seriesTmdbId String
+  userId       Int
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  content      String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@unique([seriesTmdbId, userId])
+}
+
+model TvComment {
+  id           Int       @id @default(autoincrement())
+  seriesTmdbId String
+  userId       Int
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  content      String
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+  importedAt   DateTime?
+
+  @@index([seriesTmdbId])
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -10,6 +10,7 @@ import fastifyJwt from '@fastify/jwt';
 import { config, LOGGER } from './registry.js';
 import { authRoutes } from './auth/auth-routes.js';
 import { movieRoutes } from './movies/movie-routes.js';
+import { tvRoutes } from './tv-shows/tv-show-routes.js';
 
 const logger = LOGGER.child({ module: 'index' });
 
@@ -54,6 +55,7 @@ await server.register(fastifyJwt, {
 
 await server.register(authRoutes, { prefix: '/api/auth' });
 await server.register(movieRoutes, { prefix: '/api/movies' });
+await server.register(tvRoutes, { prefix: '/api/tv' });
 
 server.get('/health', () => ({ status: 'ok' }));
 

--- a/packages/backend/src/movies/import-service.ts
+++ b/packages/backend/src/movies/import-service.ts
@@ -7,6 +7,8 @@ import { createCommentService } from '../comments/comment-service.js';
 import { createMovieService } from './movie-service.js';
 import { createRatingService } from '../ratings/rating-service.js';
 import { createWatchService } from '../watch/watch-service.js';
+import { createTvRatingService } from '../tv-shows/tv-rating-service.js';
+import { createTvWatchService } from '../tv-shows/tv-watch-service.js';
 import type {
   TraktExport,
   TraktMovie,
@@ -87,6 +89,8 @@ type ParsedCsvResult<T> =
 
 type TraktMovieRatingEntry = Extract<TraktRatingEntry, { type: 'movie' }>;
 type TraktMovieHistoryEntry = Extract<TraktHistoryEntry, { type: 'movie' }>;
+type TraktShowRatingEntry = Extract<TraktRatingEntry, { type: 'show' }>;
+type TraktEpisodeHistoryEntry = Extract<TraktHistoryEntry, { type: 'episode' }>;
 
 function normalizeFilmtipsetCsvRow(rawLine: unknown[]): unknown[] {
   if (rawLine.length === 3 && typeof rawLine[0] === 'string' && rawLine[0].includes(',')) {
@@ -312,6 +316,71 @@ async function importFromTraktExport(
     } catch (error) {
       logger.error({ err: error, row }, 'Failed to import Trakt watch history');
       errors.push('Watch import failed');
+      skippedCount += 1;
+    }
+  }
+
+  // Import TV show ratings (show-level, seasonNumber=0)
+  const tvRatingService = createTvRatingService({ logger });
+  const tvRatingRows = traktExport.ratings
+    .filter((entry): entry is TraktShowRatingEntry => entry.type === 'show')
+    .filter(entry => typeof entry.show.ids?.tmdb === 'number');
+
+  for (const entry of tvRatingRows) {
+    const seriesTmdbId = String(entry.show.ids.tmdb!);
+    const ratedAt = new Date(entry.rated_at);
+    if (Number.isNaN(ratedAt.getTime())) {
+      errors.push(`TV rating import skipped: invalid date for series ${seriesTmdbId}`);
+      skippedCount += 1;
+      continue;
+    }
+    try {
+      await tvRatingService.upsertTvRating(
+        seriesTmdbId,
+        0,
+        userId,
+        entry.rating,
+        ratedAt,
+        importTimestamp,
+        TRAKT_SOURCE
+      );
+      importedCount += 1;
+    } catch (error) {
+      logger.error({ err: error, entry }, 'Failed to import Trakt TV rating');
+      errors.push('TV rating import failed');
+      skippedCount += 1;
+    }
+  }
+
+  // Import TV episode watch history
+  const tvWatchService = createTvWatchService({ logger });
+  const episodeHistoryRows = traktExport.history
+    .filter((entry): entry is TraktEpisodeHistoryEntry => entry.type === 'episode')
+    .filter(entry => typeof entry.show.ids?.tmdb === 'number');
+
+  for (const entry of episodeHistoryRows) {
+    const seriesTmdbId = String(entry.show.ids.tmdb!);
+    const watchedAt = new Date(entry.watched_at);
+    if (Number.isNaN(watchedAt.getTime())) {
+      errors.push(
+        `TV watch import skipped: invalid date for series ${seriesTmdbId} S${entry.episode.season}E${entry.episode.number}`
+      );
+      skippedCount += 1;
+      continue;
+    }
+    try {
+      await tvWatchService.createWatchEntryIfMissing(
+        seriesTmdbId,
+        entry.episode.season,
+        entry.episode.number,
+        userId,
+        watchedAt,
+        TRAKT_SOURCE
+      );
+      importedCount += 1;
+    } catch (error) {
+      logger.error({ err: error, entry }, 'Failed to import Trakt TV episode history');
+      errors.push('TV episode watch import failed');
       skippedCount += 1;
     }
   }

--- a/packages/backend/src/tv-shows/tv-comment-service.ts
+++ b/packages/backend/src/tv-shows/tv-comment-service.ts
@@ -1,0 +1,80 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { LOGGER } from '../registry.js';
+import { prisma } from '../lib/prisma.js';
+import { HttpError } from '../lib/http-error.js';
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+export function createTvCommentService(options?: ServiceOptions) {
+  const serviceLogger = options?.logger ?? LOGGER;
+
+  const localLogger = (context: string) =>
+    serviceLogger.child({ module: 'tv-comment-service', context });
+
+  return {
+    async getCommentsForSeries(seriesTmdbId: string) {
+      const logger = localLogger('getCommentsForSeries');
+      logger.debug({ seriesTmdbId }, 'Fetching comments for TV series');
+
+      return prisma.tvComment.findMany({
+        where: { seriesTmdbId },
+        orderBy: [{ createdAt: 'desc' }],
+        include: {
+          user: {
+            select: {
+              id: true,
+              username: true,
+            },
+          },
+        },
+      });
+    },
+
+    async createComment(
+      seriesTmdbId: string,
+      userId: number,
+      content: string,
+      createdAt?: Date,
+      importedAt?: Date
+    ) {
+      const logger = localLogger('createComment');
+      logger.debug({ seriesTmdbId, userId, createdAt, importedAt }, 'Creating TV comment');
+
+      return prisma.tvComment.create({
+        data: {
+          seriesTmdbId,
+          userId,
+          content,
+          ...(createdAt ? { createdAt } : {}),
+          ...(importedAt ? { importedAt } : {}),
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              username: true,
+            },
+          },
+        },
+      });
+    },
+
+    async deleteComment(seriesTmdbId: string, commentId: number, userId: number) {
+      const logger = localLogger('deleteComment');
+      logger.debug({ seriesTmdbId, commentId, userId }, 'Deleting TV comment');
+
+      const result = await prisma.tvComment.deleteMany({
+        where: { id: commentId, seriesTmdbId, userId },
+      });
+
+      if (result.count === 0) {
+        throw new HttpError('Comment not found', { statusCode: 404 });
+      }
+    },
+  };
+}

--- a/packages/backend/src/tv-shows/tv-rating-service.ts
+++ b/packages/backend/src/tv-shows/tv-rating-service.ts
@@ -1,0 +1,72 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { LOGGER } from '../registry.js';
+import { prisma } from '../lib/prisma.js';
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+export function createTvRatingService(options?: ServiceOptions) {
+  const serviceLogger = options?.logger ?? LOGGER;
+
+  const localLogger = (context: string) =>
+    serviceLogger.child({ module: 'tv-rating-service', context });
+
+  return {
+    async upsertTvRating(
+      seriesTmdbId: string,
+      seasonNumber: number,
+      userId: number,
+      score: number,
+      ratedAt?: Date,
+      importedAt?: Date,
+      source = 'manual'
+    ) {
+      const logger = localLogger('upsertTvRating');
+      logger.debug(
+        { seriesTmdbId, seasonNumber, userId, score, ratedAt, importedAt, source },
+        'Upserting TV rating'
+      );
+
+      return prisma.tvRating.upsert({
+        where: {
+          seriesTmdbId_seasonNumber_userId: { seriesTmdbId, seasonNumber, userId },
+        },
+        update: {
+          score,
+          source,
+          ...(ratedAt ? { ratedAt } : {}),
+          ...(importedAt ? { importedAt } : {}),
+        },
+        create: {
+          seriesTmdbId,
+          seasonNumber,
+          userId,
+          score,
+          source,
+          ...(ratedAt ? { ratedAt } : {}),
+          ...(importedAt ? { importedAt } : {}),
+        },
+      });
+    },
+
+    async deleteTvRating(seriesTmdbId: string, seasonNumber: number, userId: number) {
+      const logger = localLogger('deleteTvRating');
+      logger.debug({ seriesTmdbId, seasonNumber, userId }, 'Deleting TV rating');
+      await prisma.tvRating.deleteMany({ where: { seriesTmdbId, seasonNumber, userId } });
+    },
+
+    async getTvRatingsForSeries(seriesTmdbId: string, userId: number) {
+      const logger = localLogger('getTvRatingsForSeries');
+      logger.debug({ seriesTmdbId, userId }, 'Fetching TV ratings for series');
+
+      return prisma.tvRating.findMany({
+        where: { seriesTmdbId, userId },
+        orderBy: { seasonNumber: 'asc' },
+      });
+    },
+  };
+}

--- a/packages/backend/src/tv-shows/tv-review-service.ts
+++ b/packages/backend/src/tv-shows/tv-review-service.ts
@@ -1,0 +1,36 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { LOGGER } from '../registry.js';
+import { prisma } from '../lib/prisma.js';
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+export function createTvReviewService(options?: ServiceOptions) {
+  const serviceLogger = options?.logger ?? LOGGER;
+
+  const localLogger = (context: string) =>
+    serviceLogger.child({ module: 'tv-review-service', context });
+
+  return {
+    async upsertTvReview(seriesTmdbId: string, userId: number, content: string) {
+      const logger = localLogger('upsertTvReview');
+      logger.debug({ seriesTmdbId, userId }, 'Upserting TV review');
+
+      return prisma.tvReview.upsert({
+        where: { seriesTmdbId_userId: { seriesTmdbId, userId } },
+        update: { content },
+        create: { seriesTmdbId, userId, content },
+      });
+    },
+
+    async deleteTvReview(seriesTmdbId: string, userId: number) {
+      const logger = localLogger('deleteTvReview');
+      logger.debug({ seriesTmdbId, userId }, 'Deleting TV review');
+      await prisma.tvReview.deleteMany({ where: { seriesTmdbId, userId } });
+    },
+  };
+}

--- a/packages/backend/src/tv-shows/tv-show-routes.ts
+++ b/packages/backend/src/tv-shows/tv-show-routes.ts
@@ -1,0 +1,321 @@
+import type { FastifyPluginCallbackZod } from 'fastify-type-provider-zod';
+import { HTTPError } from 'got';
+import { z } from 'zod';
+import { authenticate } from '../auth/auth-middleware.js';
+import { HttpError } from '../lib/http-error.js';
+import { createTvShowService } from './tv-show-service.js';
+import { createTvUserDataService } from './tv-user-data-service.js';
+import { createTvWatchService } from './tv-watch-service.js';
+import { createTvRatingService } from './tv-rating-service.js';
+import { createTvReviewService } from './tv-review-service.js';
+import { createTvCommentService } from './tv-comment-service.js';
+import { TV_USER_FILTER_VALUES } from './tv-show-types.js';
+import type { TvSortBy, TvUserFilterValue } from './tv-show-types.js';
+
+const PAGE_SIZE = 20;
+
+const listQuerySchema = z.object({
+  search: z.string().optional(),
+  series_id: z.string().optional(),
+  page: z.coerce.number().int().positive().default(1),
+  sort_by: z.enum(['popularity', 'rating', 'watched_date', 'my_rating']).default('popularity'),
+  user_filter: z
+    .string()
+    .transform(raw => raw.split(',').filter(Boolean))
+    .pipe(z.array(z.enum(TV_USER_FILTER_VALUES)))
+    .optional(),
+});
+
+const seriesParamsSchema = z.object({ seriesId: z.string().min(1) });
+
+const seriesSeasonParamsSchema = z.object({
+  seriesId: z.string().min(1),
+  seasonNumber: z.coerce.number().int().min(0),
+});
+
+const watchBodySchema = z.object({
+  seasonNumber: z.number().int().min(1),
+  episodeNumber: z.number().int().min(1),
+  watchedAt: z.string().datetime(),
+});
+
+const unwatchBodySchema = z.object({
+  seasonNumber: z.number().int().min(1),
+  episodeNumber: z.number().int().min(1),
+});
+
+const ratingBodySchema = z.object({
+  score: z.number().int().min(1).max(5),
+});
+
+const reviewBodySchema = z.object({
+  content: z.string().min(1).max(5000),
+});
+
+const commentBodySchema = z.object({
+  content: z.string().min(1).max(1000),
+});
+
+const deleteCommentParamsSchema = z.object({
+  seriesId: z.string().min(1),
+  commentId: z.coerce.number().int().positive(),
+});
+
+function handleNotFound(error: unknown): never {
+  if (error instanceof HTTPError && error.response.statusCode === 404) {
+    throw new HttpError('TV show not found', { statusCode: 404, cause: error });
+  }
+  throw error;
+}
+
+const SORT_REQUIRED_FILTER: Partial<Record<TvSortBy, TvUserFilterValue>> = {
+  watched_date: 'watched',
+  my_rating: 'rated',
+};
+
+export const tvRoutes: FastifyPluginCallbackZod = (fastify, _options, done) => {
+  fastify.get('/', { schema: { querystring: listQuerySchema } }, async (request, reply) => {
+    const { series_id, search, page, sort_by, user_filter } = request.query;
+
+    const requiredFilter = SORT_REQUIRED_FILTER[sort_by];
+    if (requiredFilter !== undefined && !user_filter?.includes(requiredFilter)) {
+      return reply
+        .code(400)
+        .send({ error: `sort_by=${sort_by} requires user_filter to include "${requiredFilter}"` });
+    }
+
+    if (series_id !== undefined) {
+      const tvService = createTvShowService({ logger: request.log });
+      const show = await tvService.getTvShowById(series_id).catch(handleNotFound);
+      return reply.send({ results: [show], page: 1, total_pages: 1, total_results: 1 });
+    }
+
+    if (search) {
+      const tvService = createTvShowService({ logger: request.log });
+      const data = await tvService.searchTvShows(search, page);
+      return reply.send(data);
+    }
+
+    if (user_filter && user_filter.length > 0) {
+      try {
+        await request.jwtVerify();
+      } catch {
+        return reply.code(401).send({ error: 'Unauthorized' });
+      }
+
+      const userDataService = createTvUserDataService({ logger: request.log });
+      const seriesIds = await userDataService.getFilteredSeriesTmdbIds(
+        request.user.userId,
+        user_filter,
+        sort_by
+      );
+
+      if (seriesIds.length === 0) {
+        return reply.send({ results: [], page: 1, total_pages: 1, total_results: 0 });
+      }
+
+      const totalResults = seriesIds.length;
+      const totalPages = Math.ceil(totalResults / PAGE_SIZE);
+      const pageIds = seriesIds.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+      const tvService = createTvShowService({ logger: request.log });
+      const results = await Promise.all(pageIds.map(id => tvService.getTvShowById(id)));
+      return reply.send({ results, page, total_pages: totalPages, total_results: totalResults });
+    }
+
+    const tvService = createTvShowService({ logger: request.log });
+    const data = await tvService.discoverTvShows(sort_by, page);
+    return reply.send(data);
+  });
+
+  fastify.get('/:seriesId', { schema: { params: seriesParamsSchema } }, async (request, reply) => {
+    const tvService = createTvShowService({ logger: request.log });
+    const show = await tvService.getTvShowDetails(request.params.seriesId).catch(handleNotFound);
+    return reply.send(show);
+  });
+
+  fastify.get(
+    '/:seriesId/season/:seasonNumber',
+    { schema: { params: seriesSeasonParamsSchema } },
+    async (request, reply) => {
+      const tvService = createTvShowService({ logger: request.log });
+      const season = await tvService
+        .getTvSeason(request.params.seriesId, request.params.seasonNumber)
+        .catch(handleNotFound);
+      return reply.send(season);
+    }
+  );
+
+  fastify.get(
+    '/:seriesId/user-data',
+    { preHandler: authenticate, schema: { params: seriesParamsSchema } },
+    async (request, reply) => {
+      const userDataService = createTvUserDataService({ logger: request.log });
+      const data = await userDataService.getUserTvData(
+        request.params.seriesId,
+        request.user.userId
+      );
+      return reply.send(data);
+    }
+  );
+
+  fastify.get(
+    '/:seriesId/comments',
+    { schema: { params: seriesParamsSchema } },
+    async (request, reply) => {
+      const commentService = createTvCommentService({ logger: request.log });
+      const comments = await commentService.getCommentsForSeries(request.params.seriesId);
+      return reply.send(comments);
+    }
+  );
+
+  fastify.post(
+    '/:seriesId/comments',
+    {
+      preHandler: authenticate,
+      schema: { params: seriesParamsSchema, body: commentBodySchema },
+    },
+    async (request, reply) => {
+      const commentService = createTvCommentService({ logger: request.log });
+      const comment = await commentService.createComment(
+        request.params.seriesId,
+        request.user.userId,
+        request.body.content
+      );
+      return reply.send(comment);
+    }
+  );
+
+  fastify.delete(
+    '/:seriesId/comments/:commentId',
+    {
+      preHandler: authenticate,
+      schema: { params: deleteCommentParamsSchema },
+    },
+    async (request, reply) => {
+      const commentService = createTvCommentService({ logger: request.log });
+      await commentService.deleteComment(
+        request.params.seriesId,
+        request.params.commentId,
+        request.user.userId
+      );
+      return reply.code(204).send();
+    }
+  );
+
+  fastify.put(
+    '/:seriesId/rating',
+    { preHandler: authenticate, schema: { params: seriesParamsSchema, body: ratingBodySchema } },
+    async (request, reply) => {
+      const ratingService = createTvRatingService({ logger: request.log });
+      const rating = await ratingService.upsertTvRating(
+        request.params.seriesId,
+        0,
+        request.user.userId,
+        request.body.score
+      );
+      return reply.send(rating);
+    }
+  );
+
+  fastify.delete(
+    '/:seriesId/rating',
+    { preHandler: authenticate, schema: { params: seriesParamsSchema } },
+    async (request, reply) => {
+      const ratingService = createTvRatingService({ logger: request.log });
+      await ratingService.deleteTvRating(request.params.seriesId, 0, request.user.userId);
+      return reply.code(204).send();
+    }
+  );
+
+  fastify.put(
+    '/:seriesId/season/:seasonNumber/rating',
+    {
+      preHandler: authenticate,
+      schema: { params: seriesSeasonParamsSchema, body: ratingBodySchema },
+    },
+    async (request, reply) => {
+      const ratingService = createTvRatingService({ logger: request.log });
+      const rating = await ratingService.upsertTvRating(
+        request.params.seriesId,
+        request.params.seasonNumber,
+        request.user.userId,
+        request.body.score
+      );
+      return reply.send(rating);
+    }
+  );
+
+  fastify.delete(
+    '/:seriesId/season/:seasonNumber/rating',
+    {
+      preHandler: authenticate,
+      schema: { params: seriesSeasonParamsSchema },
+    },
+    async (request, reply) => {
+      const ratingService = createTvRatingService({ logger: request.log });
+      await ratingService.deleteTvRating(
+        request.params.seriesId,
+        request.params.seasonNumber,
+        request.user.userId
+      );
+      return reply.code(204).send();
+    }
+  );
+
+  fastify.put(
+    '/:seriesId/review',
+    { preHandler: authenticate, schema: { params: seriesParamsSchema, body: reviewBodySchema } },
+    async (request, reply) => {
+      const reviewService = createTvReviewService({ logger: request.log });
+      const review = await reviewService.upsertTvReview(
+        request.params.seriesId,
+        request.user.userId,
+        request.body.content
+      );
+      return reply.send(review);
+    }
+  );
+
+  fastify.delete(
+    '/:seriesId/review',
+    { preHandler: authenticate, schema: { params: seriesParamsSchema } },
+    async (request, reply) => {
+      const reviewService = createTvReviewService({ logger: request.log });
+      await reviewService.deleteTvReview(request.params.seriesId, request.user.userId);
+      return reply.code(204).send();
+    }
+  );
+
+  fastify.put(
+    '/:seriesId/watch',
+    { preHandler: authenticate, schema: { params: seriesParamsSchema, body: watchBodySchema } },
+    async (request, reply) => {
+      const watchService = createTvWatchService({ logger: request.log });
+      const entry = await watchService.markEpisodeWatched(
+        request.params.seriesId,
+        request.body.seasonNumber,
+        request.body.episodeNumber,
+        request.user.userId,
+        new Date(request.body.watchedAt)
+      );
+      return reply.send(entry);
+    }
+  );
+
+  fastify.delete(
+    '/:seriesId/watch',
+    { preHandler: authenticate, schema: { params: seriesParamsSchema, body: unwatchBodySchema } },
+    async (request, reply) => {
+      const watchService = createTvWatchService({ logger: request.log });
+      await watchService.unmarkEpisodeWatched(
+        request.params.seriesId,
+        request.body.seasonNumber,
+        request.body.episodeNumber,
+        request.user.userId
+      );
+      return reply.code(204).send();
+    }
+  );
+
+  done();
+};

--- a/packages/backend/src/tv-shows/tv-show-service.ts
+++ b/packages/backend/src/tv-shows/tv-show-service.ts
@@ -1,0 +1,229 @@
+import { HTTPError } from 'got';
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { LOGGER } from '../registry.js';
+import { tmdbClient } from '../movies/tmdb-client.js';
+import { omdbClient } from '../movies/omdb-client.js';
+import type {
+  TmdbTvListResult,
+  TmdbTvDetail,
+  TmdbTvSearchResponse,
+  TmdbTvSeasonDetail,
+  OmdbTvResponse,
+  TvShowListItem,
+  TvShowDetail,
+  TvSeason,
+  TvEpisode,
+  TvSortBy,
+} from './tv-show-types.js';
+
+const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w500';
+const TMDB_BACKDROP_BASE = 'https://image.tmdb.org/t/p/w1280';
+const TMDB_STILL_BASE = 'https://image.tmdb.org/t/p/w300';
+const MIN_VOTE_COUNT = 50;
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+function extractRating(
+  ratings: { Source: string; Value: string }[],
+  source: string
+): string | null {
+  return ratings.find(rating => rating.Source === source)?.Value ?? null;
+}
+
+function mapListItem(raw: TmdbTvListResult): TvShowListItem {
+  return {
+    seriesTmdbId: String(raw.id),
+    name: raw.name,
+    posterPath: raw.poster_path ? `${TMDB_IMAGE_BASE}${raw.poster_path}` : null,
+    backdropPath: raw.backdrop_path ? `${TMDB_BACKDROP_BASE}${raw.backdrop_path}` : null,
+    voteAverage: raw.vote_average,
+    voteCount: raw.vote_count,
+    firstAirDate: raw.first_air_date,
+    overview: raw.overview,
+  };
+}
+
+export function createTvShowService(options?: ServiceOptions) {
+  const serviceLogger = options?.logger ?? LOGGER;
+
+  const localLogger = (context: string) =>
+    serviceLogger.child({ module: 'tv-show-service', context });
+
+  async function fetchOmdbData(imdbId: string): Promise<OmdbTvResponse | null> {
+    const logger = localLogger('fetchOmdbData');
+    try {
+      const response = await omdbClient
+        .get('', { searchParams: { i: imdbId } })
+        .json<OmdbTvResponse>();
+      if (response.Response === 'False') return null;
+      return response;
+    } catch (error) {
+      logger.error({ imdbId, err: error }, 'Failed to fetch OMDB data for TV show');
+      return null;
+    }
+  }
+
+  async function searchTvShows(query: string, page = 1): Promise<TmdbTvSearchResponse> {
+    const logger = localLogger('searchTvShows');
+
+    try {
+      const response = await tmdbClient
+        .get('search/tv', {
+          searchParams: { query, page, include_adult: false },
+        })
+        .json<TmdbTvSearchResponse>();
+      return {
+        ...response,
+        results: response.results.map(mapListItem) as unknown as TmdbTvListResult[],
+      };
+    } catch (error) {
+      logger.error({ query, page, err: error }, 'TMDB TV search failed');
+      if (error instanceof HTTPError) {
+        throw new Error(`TMDB TV search failed: ${error.response.statusCode}`, { cause: error });
+      }
+      throw error;
+    }
+  }
+
+  async function discoverTvShows(
+    sortBy: TvSortBy = 'popularity',
+    page = 1
+  ): Promise<TmdbTvSearchResponse> {
+    const logger = localLogger('discoverTvShows');
+    const tmdbSortBy = sortBy === 'rating' ? 'vote_average.desc' : 'popularity.desc';
+
+    try {
+      const response = await tmdbClient
+        .get('discover/tv', {
+          searchParams: {
+            sort_by: tmdbSortBy,
+            page,
+            [`vote_count.gte`]: MIN_VOTE_COUNT,
+            include_adult: false,
+          },
+        })
+        .json<TmdbTvSearchResponse>();
+      return {
+        ...response,
+        results: response.results.map(mapListItem) as unknown as TmdbTvListResult[],
+      };
+    } catch (error) {
+      logger.error({ sortBy, page, err: error }, 'TMDB TV discover failed');
+      if (error instanceof HTTPError) {
+        throw new Error(`TMDB TV discover failed: ${error.response.statusCode}`, { cause: error });
+      }
+      throw error;
+    }
+  }
+
+  async function getTvShowById(seriesTmdbId: string): Promise<TvShowListItem> {
+    const logger = localLogger('getTvShowById');
+
+    try {
+      const show = await tmdbClient.get(`tv/${seriesTmdbId}`).json<TmdbTvListResult>();
+      return mapListItem(show);
+    } catch (error) {
+      logger.error({ seriesTmdbId, err: error }, 'TMDB TV request failed');
+      if (error instanceof HTTPError) {
+        throw new Error(`TMDB TV request failed: ${error.response.statusCode}`, { cause: error });
+      }
+      throw error;
+    }
+  }
+
+  async function getTvShowDetails(seriesTmdbId: string): Promise<TvShowDetail> {
+    const logger = localLogger('getTvShowDetails');
+
+    try {
+      const detail = await tmdbClient
+        .get(`tv/${seriesTmdbId}`, {
+          searchParams: { append_to_response: 'external_ids' },
+        })
+        .json<TmdbTvDetail>();
+
+      const imdbId = detail.external_ids?.imdb_id ?? null;
+      const omdb = imdbId ? await fetchOmdbData(imdbId) : null;
+
+      const averageRuntime =
+        detail.episode_run_time.length > 0
+          ? Math.round(
+              detail.episode_run_time.reduce((sum, rt) => sum + rt, 0) /
+                detail.episode_run_time.length
+            )
+          : null;
+
+      return {
+        seriesTmdbId: String(detail.id),
+        name: detail.name,
+        posterPath: detail.poster_path ? `${TMDB_IMAGE_BASE}${detail.poster_path}` : null,
+        backdropPath: detail.backdrop_path ? `${TMDB_BACKDROP_BASE}${detail.backdrop_path}` : null,
+        voteAverage: detail.vote_average,
+        voteCount: detail.vote_count,
+        firstAirDate: detail.first_air_date,
+        overview: detail.overview,
+        genres: detail.genres,
+        numberOfSeasons: detail.number_of_seasons,
+        numberOfEpisodes: detail.number_of_episodes,
+        status: detail.status,
+        networks: detail.networks,
+        averageRuntime,
+        externalRatings: {
+          imdbId,
+          imdbRating: omdb?.imdbRating ?? null,
+          rottenTomatoes: omdb ? extractRating(omdb.Ratings, 'Rotten Tomatoes') : null,
+          metacritic: omdb ? extractRating(omdb.Ratings, 'Metacritic') : null,
+        },
+        tmdbUrl: `https://www.themoviedb.org/tv/${seriesTmdbId}`,
+        imdbUrl: imdbId ? `https://www.imdb.com/title/${imdbId}/` : null,
+        rtSearchUrl: `https://www.rottentomatoes.com/search?search=${encodeURIComponent(detail.name)}`,
+      };
+    } catch (error) {
+      logger.error({ seriesTmdbId, err: error }, 'TMDB TV details request failed');
+      if (error instanceof HTTPError) {
+        throw new Error(`TMDB TV details failed: ${error.response.statusCode}`, { cause: error });
+      }
+      throw error;
+    }
+  }
+
+  async function getTvSeason(seriesTmdbId: string, seasonNumber: number): Promise<TvSeason> {
+    const logger = localLogger('getTvSeason');
+
+    try {
+      const season = await tmdbClient
+        .get(`tv/${seriesTmdbId}/season/${seasonNumber}`)
+        .json<TmdbTvSeasonDetail>();
+
+      const episodes: TvEpisode[] = season.episodes.map(ep => ({
+        episodeNumber: ep.episode_number,
+        name: ep.name,
+        overview: ep.overview,
+        airDate: ep.air_date,
+        runtime: ep.runtime,
+        stillPath: ep.still_path ? `${TMDB_STILL_BASE}${ep.still_path}` : null,
+      }));
+
+      return {
+        seasonNumber: season.season_number,
+        name: season.name,
+        overview: season.overview,
+        posterPath: season.poster_path ? `${TMDB_IMAGE_BASE}${season.poster_path}` : null,
+        airDate: season.air_date,
+        episodes,
+      };
+    } catch (error) {
+      logger.error({ seriesTmdbId, seasonNumber, err: error }, 'TMDB TV season request failed');
+      if (error instanceof HTTPError) {
+        throw new Error(`TMDB TV season failed: ${error.response.statusCode}`, { cause: error });
+      }
+      throw error;
+    }
+  }
+
+  return { searchTvShows, discoverTvShows, getTvShowById, getTvShowDetails, getTvSeason };
+}

--- a/packages/backend/src/tv-shows/tv-show-types.ts
+++ b/packages/backend/src/tv-shows/tv-show-types.ts
@@ -1,0 +1,131 @@
+export interface TmdbTvListResult {
+  id: number;
+  name: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  first_air_date: string;
+  overview: string;
+  genre_ids: number[];
+}
+
+export interface TmdbTvDetail {
+  id: number;
+  name: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  vote_average: number;
+  vote_count: number;
+  first_air_date: string;
+  overview: string;
+  genres: { id: number; name: string }[];
+  number_of_seasons: number;
+  number_of_episodes: number;
+  status: string;
+  networks: { id: number; name: string }[];
+  episode_run_time: number[];
+  external_ids: {
+    imdb_id: string | null;
+  };
+}
+
+export interface TmdbTvSearchResponse {
+  results: TmdbTvListResult[];
+  page: number;
+  total_pages: number;
+  total_results: number;
+}
+
+export interface TmdbTvSeasonDetail {
+  id: number;
+  season_number: number;
+  name: string;
+  overview: string;
+  poster_path: string | null;
+  air_date: string | null;
+  episodes: TmdbTvEpisode[];
+}
+
+export interface TmdbTvEpisode {
+  id: number;
+  episode_number: number;
+  name: string;
+  overview: string;
+  air_date: string | null;
+  runtime: number | null;
+  still_path: string | null;
+}
+
+export interface TvShowListItem {
+  seriesTmdbId: string;
+  name: string;
+  posterPath: string | null;
+  backdropPath: string | null;
+  voteAverage: number;
+  voteCount: number;
+  firstAirDate: string;
+  overview: string;
+}
+
+export interface TvShowListResponse {
+  results: TvShowListItem[];
+  page: number;
+  total_pages: number;
+  total_results: number;
+}
+
+export interface ExternalTvRatings {
+  imdbId: string | null;
+  imdbRating: string | null;
+  rottenTomatoes: string | null;
+  metacritic: string | null;
+}
+
+export interface TvShowDetail extends TvShowListItem {
+  genres: { id: number; name: string }[];
+  numberOfSeasons: number;
+  numberOfEpisodes: number;
+  status: string;
+  networks: { id: number; name: string }[];
+  averageRuntime: number | null;
+  externalRatings: ExternalTvRatings;
+  tmdbUrl: string;
+  imdbUrl: string | null;
+  rtSearchUrl: string;
+}
+
+export interface TvEpisode {
+  episodeNumber: number;
+  name: string;
+  overview: string;
+  airDate: string | null;
+  runtime: number | null;
+  stillPath: string | null;
+}
+
+export interface TvSeason {
+  seasonNumber: number;
+  name: string;
+  overview: string;
+  posterPath: string | null;
+  airDate: string | null;
+  episodes: TvEpisode[];
+}
+
+export type TvSortBy = 'popularity' | 'rating' | 'watched_date' | 'my_rating';
+
+export const TV_USER_FILTER_VALUES = ['rated', 'watched', 'reviewed', 'commented'] as const;
+export type TvUserFilterValue = (typeof TV_USER_FILTER_VALUES)[number];
+
+export interface OmdbRating {
+  Source: string;
+  Value: string;
+}
+
+export interface OmdbTvResponse {
+  imdbRating: string;
+  Ratings: OmdbRating[];
+  Response: 'True' | 'False';
+  Error?: string;
+}

--- a/packages/backend/src/tv-shows/tv-user-data-service.ts
+++ b/packages/backend/src/tv-shows/tv-user-data-service.ts
@@ -1,0 +1,139 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { LOGGER } from '../registry.js';
+import { prisma } from '../lib/prisma.js';
+import type { TvSortBy, TvUserFilterValue } from './tv-show-types.js';
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+export function createTvUserDataService(options?: ServiceOptions) {
+  const serviceLogger = options?.logger ?? LOGGER;
+
+  const localLogger = (context: string) =>
+    serviceLogger.child({ module: 'tv-user-data-service', context });
+
+  async function fetchSeriesIdsForFilter(
+    userId: number,
+    filter: TvUserFilterValue
+  ): Promise<string[]> {
+    if (filter === 'rated') {
+      const records = await prisma.tvRating.findMany({
+        where: { userId, seasonNumber: 0 },
+        select: { seriesTmdbId: true },
+      });
+      return records.map(record => record.seriesTmdbId);
+    }
+    if (filter === 'watched') {
+      const records = await prisma.tvWatchEntry.findMany({
+        where: { userId },
+        select: { seriesTmdbId: true },
+        distinct: ['seriesTmdbId'],
+      });
+      return records.map(record => record.seriesTmdbId);
+    }
+    if (filter === 'reviewed') {
+      const records = await prisma.tvReview.findMany({
+        where: { userId },
+        select: { seriesTmdbId: true },
+      });
+      return records.map(record => record.seriesTmdbId);
+    }
+
+    const records = await prisma.tvComment.findMany({
+      where: { userId },
+      select: { seriesTmdbId: true },
+      distinct: ['seriesTmdbId'],
+    });
+    return records.map(record => record.seriesTmdbId);
+  }
+
+  return {
+    async getFilteredSeriesTmdbIds(
+      userId: number,
+      filters: TvUserFilterValue[],
+      sortBy?: TvSortBy
+    ): Promise<string[]> {
+      const logger = localLogger('getFilteredSeriesTmdbIds');
+      logger.debug({ userId, filters, sortBy }, 'Fetching filtered TV series IDs');
+
+      if (sortBy === 'watched_date') {
+        const entries = await prisma.tvWatchEntry.findMany({
+          where: { userId },
+          orderBy: [{ watchedAt: 'desc' }],
+          select: { seriesTmdbId: true },
+          distinct: ['seriesTmdbId'],
+        });
+        const orderedIds = entries.map(entry => entry.seriesTmdbId);
+        const intersectionFilters = filters.filter(filterVal => filterVal !== 'watched');
+        if (intersectionFilters.length === 0) return orderedIds;
+        const intersectionIdSets = await Promise.all(
+          intersectionFilters.map(filterVal => fetchSeriesIdsForFilter(userId, filterVal))
+        );
+        const additionalIds = new Set(intersectionIdSets.flat());
+        return orderedIds.filter(id => additionalIds.has(id));
+      }
+
+      if (sortBy === 'my_rating') {
+        const entries = await prisma.tvRating.findMany({
+          where: { userId, seasonNumber: 0 },
+          orderBy: [{ score: 'desc' }],
+          select: { seriesTmdbId: true },
+        });
+        const orderedIds = entries.map(entry => entry.seriesTmdbId);
+        const intersectionFilters = filters.filter(filterVal => filterVal !== 'rated');
+        if (intersectionFilters.length === 0) return orderedIds;
+        const intersectionIdSets = await Promise.all(
+          intersectionFilters.map(filterVal => fetchSeriesIdsForFilter(userId, filterVal))
+        );
+        const additionalIds = new Set(intersectionIdSets.flat());
+        return orderedIds.filter(id => additionalIds.has(id));
+      }
+
+      const idSets = await Promise.all(
+        filters.map(filterVal => fetchSeriesIdsForFilter(userId, filterVal))
+      );
+      return Array.from(new Set(idSets.flat()));
+    },
+
+    async getUserTvData(seriesTmdbId: string, userId: number) {
+      const logger = localLogger('getUserTvData');
+      logger.debug({ seriesTmdbId, userId }, 'Loading user TV show data');
+
+      const [watchEntries, ratings, review] = await Promise.all([
+        prisma.tvWatchEntry.findMany({
+          where: { seriesTmdbId, userId },
+          orderBy: [{ seasonNumber: 'asc' }, { episodeNumber: 'asc' }],
+          select: { seasonNumber: true, episodeNumber: true, watchedAt: true },
+        }),
+        prisma.tvRating.findMany({
+          where: { seriesTmdbId, userId },
+          orderBy: { seasonNumber: 'asc' },
+          select: { seasonNumber: true, score: true },
+        }),
+        prisma.tvReview.findUnique({ where: { seriesTmdbId_userId: { seriesTmdbId, userId } } }),
+      ]);
+
+      const showRating = ratings.find(rating => rating.seasonNumber === 0);
+      const seasonRatings = Object.fromEntries(
+        ratings
+          .filter(rating => rating.seasonNumber !== 0)
+          .map(rating => [rating.seasonNumber, rating.score])
+      );
+
+      return {
+        watchEntries: watchEntries.map(entry => ({
+          seasonNumber: entry.seasonNumber,
+          episodeNumber: entry.episodeNumber,
+          watchedAt: entry.watchedAt,
+        })),
+        showRating: showRating ? { score: showRating.score } : null,
+        seasonRatings,
+        review: review ? { content: review.content } : null,
+      };
+    },
+  };
+}

--- a/packages/backend/src/tv-shows/tv-watch-service.ts
+++ b/packages/backend/src/tv-shows/tv-watch-service.ts
@@ -1,0 +1,105 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { LOGGER } from '../registry.js';
+import { prisma } from '../lib/prisma.js';
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+export function createTvWatchService(options?: ServiceOptions) {
+  const serviceLogger = options?.logger ?? LOGGER;
+
+  const localLogger = (context: string) =>
+    serviceLogger.child({ module: 'tv-watch-service', context });
+
+  return {
+    async markEpisodeWatched(
+      seriesTmdbId: string,
+      seasonNumber: number,
+      episodeNumber: number,
+      userId: number,
+      watchedAt: Date,
+      source = 'manual'
+    ) {
+      const logger = localLogger('markEpisodeWatched');
+      logger.debug(
+        { seriesTmdbId, seasonNumber, episodeNumber, userId, watchedAt, source },
+        'Upserting TV watch entry'
+      );
+
+      return prisma.tvWatchEntry.upsert({
+        where: {
+          seriesTmdbId_seasonNumber_episodeNumber_userId: {
+            seriesTmdbId,
+            seasonNumber,
+            episodeNumber,
+            userId,
+          },
+        },
+        update: { watchedAt, source },
+        create: { seriesTmdbId, seasonNumber, episodeNumber, userId, watchedAt, source },
+      });
+    },
+
+    async unmarkEpisodeWatched(
+      seriesTmdbId: string,
+      seasonNumber: number,
+      episodeNumber: number,
+      userId: number
+    ) {
+      const logger = localLogger('unmarkEpisodeWatched');
+      logger.debug(
+        { seriesTmdbId, seasonNumber, episodeNumber, userId },
+        'Deleting TV watch entry'
+      );
+      await prisma.tvWatchEntry.deleteMany({
+        where: { seriesTmdbId, seasonNumber, episodeNumber, userId },
+      });
+    },
+
+    async getWatchEntriesForSeries(seriesTmdbId: string, userId: number) {
+      const logger = localLogger('getWatchEntriesForSeries');
+      logger.debug({ seriesTmdbId, userId }, 'Fetching TV watch entries for series');
+
+      return prisma.tvWatchEntry.findMany({
+        where: { seriesTmdbId, userId },
+        orderBy: [{ seasonNumber: 'asc' }, { episodeNumber: 'asc' }],
+      });
+    },
+
+    async createWatchEntryIfMissing(
+      seriesTmdbId: string,
+      seasonNumber: number,
+      episodeNumber: number,
+      userId: number,
+      watchedAt: Date,
+      source = 'manual'
+    ) {
+      const logger = localLogger('createWatchEntryIfMissing');
+      logger.debug(
+        { seriesTmdbId, seasonNumber, episodeNumber, userId, watchedAt, source },
+        'Creating TV watch entry only if missing'
+      );
+
+      const existing = await prisma.tvWatchEntry.findUnique({
+        where: {
+          seriesTmdbId_seasonNumber_episodeNumber_userId: {
+            seriesTmdbId,
+            seasonNumber,
+            episodeNumber,
+            userId,
+          },
+        },
+      });
+
+      if (existing) return existing;
+
+      return prisma.tvWatchEntry.create({
+        data: { seriesTmdbId, seasonNumber, episodeNumber, userId, watchedAt, source },
+      });
+    },
+  };
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import Layout from '@/components/layout/Layout';
 import MoviesPage from '@/pages/movies/MoviesPage';
 import MovieDetailsPage from '@/pages/movie-details/MovieDetailsPage';
+import TvShowsPage from '@/pages/tv-shows/TvShowsPage';
+import TvShowDetailsPage from '@/pages/tv-show-details/TvShowDetailsPage';
 import ProfilePage from '@/pages/profile/ProfilePage';
 import LoginPage from '@/pages/auth/LoginPage';
 import RegisterPage from '@/pages/auth/RegisterPage';
@@ -13,6 +15,8 @@ export default function App() {
         <Route index element={<Navigate to="/movies" replace />} />
         <Route path="movies" element={<MoviesPage />} />
         <Route path="movies/:tmdbId" element={<MovieDetailsPage />} />
+        <Route path="tv" element={<TvShowsPage />} />
+        <Route path="tv/:seriesId" element={<TvShowDetailsPage />} />
         <Route path="profile" element={<ProfilePage />} />
         <Route path="login" element={<LoginPage />} />
         <Route path="register" element={<RegisterPage />} />

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { Film, LogOut, User } from 'lucide-react';
+import { Film, LogOut, Tv, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -20,14 +20,25 @@ export default function Header() {
           <span>Velara</span>
         </Link>
 
-        <nav className="flex items-center gap-2">
+        <nav className="flex items-center gap-1">
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/movies" className="flex items-center gap-1.5 text-sm">
+              <Film className="h-4 w-4" />
+              <span className="hidden sm:inline">Movies</span>
+            </Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/tv" className="flex items-center gap-1.5 text-sm">
+              <Tv className="h-4 w-4" />
+              <span className="hidden sm:inline">TV Shows</span>
+            </Link>
+          </Button>
           {user ? (
             <>
               <Button variant="ghost" size="sm" asChild>
                 <Link
                   to="/profile"
-                  className="flex items-center gap-1.5 text-sm text-muted-foreground"
-                >
+                  className="flex items-center gap-1.5 text-sm text-muted-foreground">
                   <User className="h-4 w-4" />
                   {user.username}
                 </Link>

--- a/packages/frontend/src/components/tv-shows/EpisodeRow.tsx
+++ b/packages/frontend/src/components/tv-shows/EpisodeRow.tsx
@@ -1,0 +1,55 @@
+import { Eye, EyeOff } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { TvEpisode } from '@/types/tv-show';
+
+interface EpisodeRowProps {
+  episode: TvEpisode;
+  isWatched: boolean;
+  onToggleWatch: () => void;
+  isAuthenticated: boolean;
+}
+
+export default function EpisodeRow({
+  episode,
+  isWatched,
+  onToggleWatch,
+  isAuthenticated,
+}: EpisodeRowProps) {
+  const airYear = episode.airDate ? new Date(episode.airDate).getFullYear() : null;
+
+  return (
+    <div className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted/50 transition-colors">
+      <span className="text-xs text-muted-foreground w-8 shrink-0 font-mono">
+        {String(episode.episodeNumber).padStart(2, '0')}
+      </span>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium leading-tight truncate">{episode.name}</p>
+        <div className="flex items-center gap-2 mt-0.5">
+          {airYear && <span className="text-xs text-muted-foreground">{airYear}</span>}
+          {episode.runtime && (
+            <Badge variant="outline" className="text-xs px-1.5 py-0 h-4">
+              {episode.runtime} min
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {isAuthenticated && (
+        <Button
+          variant={isWatched ? 'default' : 'ghost'}
+          size="sm"
+          onClick={onToggleWatch}
+          className="shrink-0 h-7 w-7 p-0">
+          {isWatched ? (
+            <Eye className="h-3.5 w-3.5" />
+          ) : (
+            <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+          <span className="sr-only">{isWatched ? 'Unmark as watched' : 'Mark as watched'}</span>
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/tv-shows/SeasonSection.tsx
+++ b/packages/frontend/src/components/tv-shows/SeasonSection.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import StarRating from '@/components/movies/StarRating';
+import EpisodeRow from './EpisodeRow';
+import type { TvSeason, TvEpisode } from '@/types/tv-show';
+
+interface SeasonSectionProps {
+  season: TvSeason;
+  watchedEpisodeKeys: Set<string>;
+  seasonRating: number | null;
+  isAuthenticated: boolean;
+  onToggleEpisode: (episode: TvEpisode) => void;
+  onSeasonRating: (seasonNumber: number, score: number) => void;
+  onClearSeasonRating: (seasonNumber: number) => void;
+}
+
+export default function SeasonSection({
+  season,
+  watchedEpisodeKeys,
+  seasonRating,
+  isAuthenticated,
+  onToggleEpisode,
+  onSeasonRating,
+  onClearSeasonRating,
+}: SeasonSectionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const watchedCount = season.episodes.filter(ep =>
+    watchedEpisodeKeys.has(`s${season.seasonNumber}e${ep.episodeNumber}`)
+  ).length;
+  const totalCount = season.episodes.length;
+
+  const handleSeasonRating = (score: number) => {
+    if (seasonRating === score) {
+      onClearSeasonRating(season.seasonNumber);
+    } else {
+      onSeasonRating(season.seasonNumber, score);
+    }
+  };
+
+  return (
+    <div className="border rounded-xl overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsOpen(prev => !prev)}
+        className="w-full flex items-center gap-4 p-4 hover:bg-muted/50 transition-colors text-left">
+        {season.posterPath && (
+          <img
+            src={season.posterPath}
+            alt={season.name}
+            className="h-16 w-11 object-cover rounded shrink-0"
+          />
+        )}
+
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold leading-tight">{season.name}</p>
+          <div className="flex items-center gap-2 mt-0.5">
+            <Badge variant="secondary" className="text-xs">
+              {watchedCount}/{totalCount} watched
+            </Badge>
+            {season.airDate && (
+              <span className="text-xs text-muted-foreground">
+                {new Date(season.airDate).getFullYear()}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {isAuthenticated && (
+          <div onClick={e => e.stopPropagation()}>
+            <StarRating value={seasonRating} onChange={handleSeasonRating} size="sm" />
+          </div>
+        )}
+
+        <span className="text-muted-foreground shrink-0">
+          {isOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="border-t divide-y divide-border/50">
+          {season.episodes.map(episode => (
+            <EpisodeRow
+              key={episode.episodeNumber}
+              episode={episode}
+              isWatched={watchedEpisodeKeys.has(`s${season.seasonNumber}e${episode.episodeNumber}`)}
+              onToggleWatch={() => onToggleEpisode(episode)}
+              isAuthenticated={isAuthenticated}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/tv-shows/TvShowCard.tsx
+++ b/packages/frontend/src/components/tv-shows/TvShowCard.tsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router-dom';
+import { Star } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { TvShowListItem } from '@/types/tv-show';
+
+interface TvShowCardProps {
+  show: TvShowListItem;
+}
+
+export default function TvShowCard({ show }: TvShowCardProps) {
+  const rating = show.voteAverage.toFixed(1);
+  const year = show.firstAirDate ? new Date(show.firstAirDate).getFullYear() : null;
+
+  return (
+    <Link
+      to={`/tv/${show.seriesTmdbId}`}
+      className="group block rounded-xl overflow-hidden bg-card border shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
+      <div className="relative aspect-[2/3] w-full overflow-hidden bg-muted">
+        {show.posterPath ? (
+          <img
+            src={show.posterPath}
+            alt={show.name}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <span className="text-4xl">📺</span>
+          </div>
+        )}
+
+        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+
+        <div className="absolute bottom-0 left-0 right-0 p-3 text-white">
+          <p className="font-semibold text-sm leading-tight line-clamp-2">{show.name}</p>
+          {year && <p className="text-xs text-white/70 mt-0.5">{year}</p>}
+        </div>
+
+        <div className="absolute top-2 right-2">
+          <Badge
+            variant="secondary"
+            className="flex items-center gap-1 bg-black/70 text-yellow-400 border-0 backdrop-blur-sm">
+            <Star className="h-3 w-3 fill-yellow-400" />
+            {rating}
+          </Badge>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/packages/frontend/src/components/tv-shows/TvShowGrid.tsx
+++ b/packages/frontend/src/components/tv-shows/TvShowGrid.tsx
@@ -1,0 +1,39 @@
+import TvShowCard from './TvShowCard';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { TvShowListItem } from '@/types/tv-show';
+
+interface TvShowGridProps {
+  shows: TvShowListItem[];
+  isLoading?: boolean;
+}
+
+const SKELETON_COUNT = 20;
+
+export default function TvShowGrid({ shows, isLoading = false }: TvShowGridProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+        {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
+          <Skeleton key={index} className="aspect-[2/3] rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (shows.length === 0) {
+    return (
+      <div className="py-20 text-center text-muted-foreground">
+        <p className="text-lg font-medium">No TV shows found</p>
+        <p className="text-sm mt-1">Try a different search term</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+      {shows.map(show => (
+        <TvShowCard key={show.seriesTmdbId} show={show} />
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useTvComments.ts
+++ b/packages/frontend/src/hooks/useTvComments.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { createTvComment, deleteTvComment, fetchTvComments } from '@/services/tv-comments-api';
+
+export function useTvComments(seriesId: string) {
+  const queryClient = useQueryClient();
+  const queryKey = ['tv-comments', seriesId];
+
+  const commentsQuery = useQuery({
+    queryKey,
+    queryFn: () => fetchTvComments(seriesId),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const addComment = useMutation({
+    mutationFn: (content: string) => createTvComment(seriesId, content),
+    onSuccess: () => {
+      toast.success('Comment posted');
+      void queryClient.invalidateQueries({ queryKey });
+    },
+    onError: () => toast.error('Failed to post comment'),
+  });
+
+  const removeComment = useMutation({
+    mutationFn: (commentId: number) => deleteTvComment(seriesId, commentId),
+    onSuccess: () => {
+      toast.success('Comment deleted');
+      void queryClient.invalidateQueries({ queryKey });
+    },
+    onError: () => toast.error('Failed to delete comment'),
+  });
+
+  return { commentsQuery, addComment, removeComment };
+}

--- a/packages/frontend/src/hooks/useTvSeason.ts
+++ b/packages/frontend/src/hooks/useTvSeason.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchTvSeason } from '@/services/tv-shows-api';
+
+export function useTvSeason(seriesId: string, seasonNumber: number) {
+  return useQuery({
+    queryKey: ['tv-season', seriesId, seasonNumber],
+    queryFn: () => fetchTvSeason(seriesId, seasonNumber),
+    staleTime: 10 * 60 * 1000,
+  });
+}

--- a/packages/frontend/src/hooks/useTvShowDetails.ts
+++ b/packages/frontend/src/hooks/useTvShowDetails.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchTvShowDetail } from '@/services/tv-shows-api';
+import { fetchUserTvData } from '@/services/user-tv-data-api';
+import { useAuth } from './useAuth';
+
+export function useTvShowDetails(seriesId: string) {
+  const { user } = useAuth();
+
+  const showQuery = useQuery({
+    queryKey: ['tv-show', seriesId],
+    queryFn: () => fetchTvShowDetail(seriesId),
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const userDataQuery = useQuery({
+    queryKey: ['user-tv-data', seriesId],
+    queryFn: () => fetchUserTvData(seriesId),
+    enabled: !!user,
+    staleTime: 0,
+  });
+
+  return { showQuery, userDataQuery };
+}

--- a/packages/frontend/src/hooks/useTvShows.ts
+++ b/packages/frontend/src/hooks/useTvShows.ts
@@ -1,0 +1,20 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { fetchTvShows } from '@/services/tv-shows-api';
+import type { TvSortBy, TvUserFilter } from '@/types/tv-show';
+
+interface UseTvShowsParams {
+  search?: string;
+  seriesId?: string;
+  page: number;
+  sortBy: TvSortBy;
+  userFilters?: TvUserFilter[];
+}
+
+export function useTvShows(params: UseTvShowsParams) {
+  return useQuery({
+    queryKey: ['tv-shows', params],
+    queryFn: () => fetchTvShows(params),
+    placeholderData: keepPreviousData,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/packages/frontend/src/hooks/useUserTvData.ts
+++ b/packages/frontend/src/hooks/useUserTvData.ts
@@ -1,0 +1,115 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  updateTvRating,
+  removeTvRating,
+  updateTvSeasonRating,
+  removeTvSeasonRating,
+  updateTvReview,
+  removeTvReview,
+  markEpisodeWatched,
+  unmarkEpisodeWatched,
+} from '@/services/user-tv-data-api';
+
+export function useUserTvData(seriesId: string) {
+  const queryClient = useQueryClient();
+  const queryKey = ['user-tv-data', seriesId];
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey });
+
+  const setShowRating = useMutation({
+    mutationFn: (score: number) => updateTvRating(seriesId, score),
+    onSuccess: () => {
+      toast.success('Rating saved');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to save rating'),
+  });
+
+  const clearShowRating = useMutation({
+    mutationFn: () => removeTvRating(seriesId),
+    onSuccess: () => {
+      toast.success('Rating removed');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to remove rating'),
+  });
+
+  const setSeasonRating = useMutation({
+    mutationFn: ({ seasonNumber, score }: { seasonNumber: number; score: number }) =>
+      updateTvSeasonRating(seriesId, seasonNumber, score),
+    onSuccess: () => {
+      toast.success('Season rating saved');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to save season rating'),
+  });
+
+  const clearSeasonRating = useMutation({
+    mutationFn: (seasonNumber: number) => removeTvSeasonRating(seriesId, seasonNumber),
+    onSuccess: () => {
+      toast.success('Season rating removed');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to remove season rating'),
+  });
+
+  const saveReview = useMutation({
+    mutationFn: (content: string) => updateTvReview(seriesId, content),
+    onSuccess: () => {
+      toast.success('Review saved');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to save review'),
+  });
+
+  const deleteReviewMutation = useMutation({
+    mutationFn: () => removeTvReview(seriesId),
+    onSuccess: () => {
+      toast.success('Review deleted');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to delete review'),
+  });
+
+  const watchEpisode = useMutation({
+    mutationFn: ({
+      seasonNumber,
+      episodeNumber,
+    }: {
+      seasonNumber: number;
+      episodeNumber: number;
+    }) => markEpisodeWatched(seriesId, seasonNumber, episodeNumber, new Date().toISOString()),
+    onSuccess: () => {
+      toast.success('Episode marked as watched');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to mark episode as watched'),
+  });
+
+  const unwatchEpisode = useMutation({
+    mutationFn: ({
+      seasonNumber,
+      episodeNumber,
+    }: {
+      seasonNumber: number;
+      episodeNumber: number;
+    }) => unmarkEpisodeWatched(seriesId, seasonNumber, episodeNumber),
+    onSuccess: () => {
+      toast.success('Episode removed from watched');
+      void invalidate();
+    },
+    onError: () => toast.error('Failed to remove episode from watched'),
+  });
+
+  return {
+    setShowRating,
+    clearShowRating,
+    setSeasonRating,
+    clearSeasonRating,
+    saveReview,
+    deleteReviewMutation,
+    watchEpisode,
+    unwatchEpisode,
+  };
+}

--- a/packages/frontend/src/pages/tv-show-details/TvShowDetailsPage.tsx
+++ b/packages/frontend/src/pages/tv-show-details/TvShowDetailsPage.tsx
@@ -1,0 +1,504 @@
+import { useMemo, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { ArrowLeft, Calendar, ExternalLink, Trash2, Tv } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Separator } from '@/components/ui/separator';
+import { Textarea } from '@/components/ui/textarea';
+import StarRating from '@/components/movies/StarRating';
+import SeasonSection from '@/components/tv-shows/SeasonSection';
+import { useTvShowDetails } from '@/hooks/useTvShowDetails';
+import { useTvComments } from '@/hooks/useTvComments';
+import { useUserTvData } from '@/hooks/useUserTvData';
+import { useTvSeason } from '@/hooks/useTvSeason';
+import { useAuth } from '@/hooks/useAuth';
+import { formatDateTime } from '@/lib/utils';
+import type { TvShowDetail, TvEpisode } from '@/types/tv-show';
+
+export default function TvShowDetailsPage() {
+  const { seriesId } = useParams<{ seriesId: string }>();
+  const id = seriesId ?? '';
+  const { user } = useAuth();
+  const { showQuery, userDataQuery } = useTvShowDetails(id);
+  const { commentsQuery, addComment, removeComment } = useTvComments(id);
+  const mutations = useUserTvData(id);
+  const [reviewText, setReviewText] = useState<string | undefined>(undefined);
+  const [commentText, setCommentText] = useState('');
+
+  const show = showQuery.data;
+  const userData = userDataQuery.data;
+  const comments = commentsQuery.data ?? [];
+
+  const currentReview = reviewText ?? userData?.review?.content ?? '';
+
+  const watchedKeys = useMemo<Set<string>>(() => {
+    if (!userData?.watchEntries) return new Set();
+    return new Set(userData.watchEntries.map(e => `s${e.seasonNumber}e${e.episodeNumber}`));
+  }, [userData?.watchEntries]);
+
+  if (showQuery.isLoading) {
+    return <TvShowDetailSkeleton />;
+  }
+
+  if (showQuery.isError || !show) {
+    return (
+      <div className="text-center py-20 text-muted-foreground">
+        <p className="text-lg font-medium">TV show not found</p>
+        <Button variant="ghost" asChild className="mt-4">
+          <Link to="/tv">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to TV shows
+          </Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const userShowRating = userData?.showRating?.score ?? null;
+  const seasonRatings = userData?.seasonRatings ?? {};
+
+  const handleShowRating = (score: number) => {
+    if (userShowRating === score) {
+      mutations.clearShowRating.mutate();
+    } else {
+      mutations.setShowRating.mutate(score);
+    }
+  };
+
+  const handleSaveReview = () => {
+    if (currentReview.trim()) {
+      mutations.saveReview.mutate(currentReview.trim());
+    } else {
+      mutations.deleteReviewMutation.mutate();
+    }
+    setReviewText(undefined);
+  };
+
+  const handlePostComment = () => {
+    const trimmed = commentText.trim();
+    if (!trimmed) return;
+    addComment.mutate(trimmed);
+    setCommentText('');
+  };
+
+  const handleEpisodeToggle = (seasonNumber: number, episode: TvEpisode) => {
+    const key = `s${seasonNumber}e${episode.episodeNumber}`;
+    if (watchedKeys.has(key)) {
+      mutations.unwatchEpisode.mutate({
+        seasonNumber,
+        episodeNumber: episode.episodeNumber,
+      });
+    } else {
+      mutations.watchEpisode.mutate({
+        seasonNumber,
+        episodeNumber: episode.episodeNumber,
+      });
+    }
+  };
+
+  const year = show.firstAirDate ? new Date(show.firstAirDate).getFullYear() : null;
+  const ratingPercent = Math.round(show.voteAverage * 10);
+
+  return (
+    <div className="space-y-8 pb-16">
+      <Button variant="ghost" size="sm" asChild className="-ml-2">
+        <Link to="/tv">
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to TV shows
+        </Link>
+      </Button>
+
+      {/* Hero */}
+      <div className="relative rounded-2xl overflow-hidden">
+        {show.backdropPath && (
+          <img
+            src={show.backdropPath}
+            alt=""
+            className="absolute inset-0 h-full w-full object-cover opacity-20"
+          />
+        )}
+        <div className="relative flex flex-col gap-6 p-6 sm:flex-row sm:items-start">
+          <div className="shrink-0 w-36 sm:w-48">
+            {show.posterPath ? (
+              <img src={show.posterPath} alt={show.name} className="rounded-xl shadow-lg w-full" />
+            ) : (
+              <div className="rounded-xl bg-muted aspect-[2/3] flex items-center justify-center text-muted-foreground text-4xl">
+                📺
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-4 flex-1">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">{show.name}</h1>
+              <div className="flex flex-wrap items-center gap-2 mt-2 text-muted-foreground text-sm">
+                {year && (
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3.5 w-3.5" />
+                    {year}
+                  </span>
+                )}
+                {show.status && (
+                  <Badge variant={show.status === 'Ended' ? 'secondary' : 'outline'}>
+                    {show.status}
+                  </Badge>
+                )}
+                {show.numberOfSeasons && (
+                  <span className="flex items-center gap-1">
+                    <Tv className="h-3.5 w-3.5" />
+                    {show.numberOfSeasons} season{show.numberOfSeasons !== 1 ? 's' : ''}
+                  </span>
+                )}
+                {show.networks && show.networks.length > 0 && (
+                  <span className="text-muted-foreground">{show.networks[0].name}</span>
+                )}
+              </div>
+            </div>
+
+            {show.genres.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {show.genres.map(genre => (
+                  <Badge key={genre.id} variant="secondary">
+                    {genre.name}
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-3">
+              <RatingBadge
+                label="TMDB"
+                value={`${ratingPercent}%`}
+                href={show.tmdbUrl}
+                color="bg-teal-500"
+              />
+              {show.externalRatings?.imdbRating && (
+                <RatingBadge
+                  label="IMDb"
+                  value={`${show.externalRatings.imdbRating}/10`}
+                  href={show.imdbUrl ?? undefined}
+                  color="bg-yellow-500"
+                />
+              )}
+              {show.externalRatings?.rottenTomatoes && (
+                <RatingBadge
+                  label="RT"
+                  value={show.externalRatings.rottenTomatoes}
+                  href={show.rtSearchUrl}
+                  color="bg-red-500"
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {show.overview && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">Overview</h2>
+          <p className="text-muted-foreground leading-relaxed">{show.overview}</p>
+        </div>
+      )}
+
+      <Separator />
+
+      {/* User tracking section */}
+      {user ? (
+        <div className="space-y-6">
+          <h2 className="text-lg font-semibold">Your Tracking</h2>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Your Rating</p>
+            <div className="flex items-center gap-3">
+              <StarRating value={userShowRating} onChange={handleShowRating} size="lg" />
+              {userShowRating && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => mutations.clearShowRating.mutate()}
+                  disabled={mutations.clearShowRating.isPending}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Your Review</p>
+            <Textarea
+              placeholder="Write your thoughts about this show…"
+              rows={4}
+              value={currentReview}
+              onChange={e => setReviewText(e.target.value)}
+              className="resize-none"
+            />
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                onClick={handleSaveReview}
+                disabled={
+                  mutations.saveReview.isPending || mutations.deleteReviewMutation.isPending
+                }>
+                {mutations.saveReview.isPending ? 'Saving…' : 'Save review'}
+              </Button>
+              {userData?.review && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => mutations.deleteReviewMutation.mutate()}
+                  disabled={mutations.deleteReviewMutation.isPending}>
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  Delete
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-xl border bg-muted/50 p-6 text-center space-y-3">
+          <p className="font-medium">Track this show</p>
+          <p className="text-sm text-muted-foreground">
+            Sign in to rate, review, and track episode progress.
+          </p>
+          <div className="flex justify-center gap-2">
+            <Button asChild size="sm">
+              <Link to="/login">Sign in</Link>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <Link to="/register">Create account</Link>
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Separator />
+
+      {/* Seasons */}
+      {show.numberOfSeasons && show.numberOfSeasons > 0 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Seasons</h2>
+          <SeasonsList
+            seriesId={id}
+            numberOfSeasons={show.numberOfSeasons}
+            watchedKeys={watchedKeys}
+            seasonRatings={seasonRatings}
+            isAuthenticated={!!user}
+            onEpisodeToggle={handleEpisodeToggle}
+            onSeasonRating={(seasonNumber, score) =>
+              mutations.setSeasonRating.mutate({ seasonNumber, score })
+            }
+            onClearSeasonRating={seasonNumber => mutations.clearSeasonRating.mutate(seasonNumber)}
+          />
+        </div>
+      )}
+
+      <Separator />
+
+      {/* Comments */}
+      <div className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Comments</h2>
+            <p className="text-sm text-muted-foreground">
+              Comments are visible to everyone. Only signed in users can post.
+            </p>
+          </div>
+          <span className="text-sm text-muted-foreground">
+            {comments.length} {comments.length === 1 ? 'comment' : 'comments'}
+          </span>
+        </div>
+
+        {user ? (
+          <div className="space-y-2 rounded-2xl border p-4">
+            <Textarea
+              placeholder="Add a comment…"
+              rows={3}
+              value={commentText}
+              onChange={e => setCommentText(e.target.value)}
+              className="resize-none"
+            />
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                onClick={handlePostComment}
+                disabled={addComment.isPending || !commentText.trim()}>
+                {addComment.isPending ? 'Posting…' : 'Post comment'}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-xl border bg-muted/50 p-6 text-sm text-muted-foreground">
+            Sign in to comment on this show.
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {commentsQuery.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading comments…</p>
+          ) : comments.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No comments yet.</p>
+          ) : (
+            comments.map(comment => (
+              <div key={comment.id} className="rounded-2xl border bg-card p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">{comment.user.username}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatDateTime(comment.createdAt)}
+                    </p>
+                  </div>
+                  {user?.id === comment.user.id && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeComment.mutate(comment.id)}
+                      disabled={removeComment.isPending}
+                      aria-label="Delete comment">
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+                <p className="mt-3 whitespace-pre-line text-sm leading-6">{comment.content}</p>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Seasons list (each season fetched individually) ──────────────────────────
+
+interface SeasonsListProps {
+  seriesId: string;
+  numberOfSeasons: number;
+  watchedKeys: Set<string>;
+  seasonRatings: Record<number, number>;
+  isAuthenticated: boolean;
+  onEpisodeToggle: (seasonNumber: number, episode: TvEpisode) => void;
+  onSeasonRating: (seasonNumber: number, score: number) => void;
+  onClearSeasonRating: (seasonNumber: number) => void;
+}
+
+function SeasonsList({
+  seriesId,
+  numberOfSeasons,
+  watchedKeys,
+  seasonRatings,
+  isAuthenticated,
+  onEpisodeToggle,
+  onSeasonRating,
+  onClearSeasonRating,
+}: SeasonsListProps) {
+  const seasonNumbers = Array.from({ length: numberOfSeasons }, (_, i) => i + 1);
+
+  return (
+    <div className="space-y-3">
+      {seasonNumbers.map(n => (
+        <SeasonLoader
+          key={n}
+          seriesId={seriesId}
+          seasonNumber={n}
+          watchedKeys={watchedKeys}
+          seasonRating={seasonRatings[n] ?? null}
+          isAuthenticated={isAuthenticated}
+          onEpisodeToggle={onEpisodeToggle}
+          onSeasonRating={onSeasonRating}
+          onClearSeasonRating={onClearSeasonRating}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface SeasonLoaderProps {
+  seriesId: string;
+  seasonNumber: number;
+  watchedKeys: Set<string>;
+  seasonRating: number | null;
+  isAuthenticated: boolean;
+  onEpisodeToggle: (seasonNumber: number, episode: TvEpisode) => void;
+  onSeasonRating: (seasonNumber: number, score: number) => void;
+  onClearSeasonRating: (seasonNumber: number) => void;
+}
+
+function SeasonLoader({
+  seriesId,
+  seasonNumber,
+  watchedKeys,
+  seasonRating,
+  isAuthenticated,
+  onEpisodeToggle,
+  onSeasonRating,
+  onClearSeasonRating,
+}: SeasonLoaderProps) {
+  const { data: season, isLoading } = useTvSeason(seriesId, seasonNumber);
+
+  if (isLoading || !season) {
+    return <Skeleton className="h-16 rounded-xl" />;
+  }
+
+  return (
+    <SeasonSection
+      season={season}
+      watchedEpisodeKeys={watchedKeys}
+      seasonRating={seasonRating}
+      isAuthenticated={isAuthenticated}
+      onToggleEpisode={episode => onEpisodeToggle(seasonNumber, episode)}
+      onSeasonRating={onSeasonRating}
+      onClearSeasonRating={onClearSeasonRating}
+    />
+  );
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+interface RatingBadgeProps {
+  label: string;
+  value: string;
+  href?: string;
+  color: string;
+}
+
+function RatingBadge({ label, value, href, color }: RatingBadgeProps) {
+  const inner = (
+    <div className="flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium hover:bg-accent transition-colors">
+      <span className={`h-2.5 w-2.5 rounded-full ${color}`} />
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-semibold">{value}</span>
+      {href && <ExternalLink className="h-3 w-3 text-muted-foreground" />}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </a>
+    );
+  }
+
+  return inner;
+}
+
+function TvShowDetailSkeleton() {
+  return (
+    <div className="space-y-8 pb-16">
+      <Skeleton className="h-8 w-24 rounded-full" />
+      <div className="flex gap-6">
+        <Skeleton className="w-36 sm:w-48 aspect-[2/3] rounded-xl" />
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-10 w-2/3" />
+          <Skeleton className="h-5 w-1/3" />
+          <Skeleton className="h-8 w-40" />
+        </div>
+      </div>
+      <Skeleton className="h-24 w-full" />
+    </div>
+  );
+}
+
+// Re-export for clarity
+export type { TvShowDetail };

--- a/packages/frontend/src/pages/tv-shows/TvShowsPage.tsx
+++ b/packages/frontend/src/pages/tv-shows/TvShowsPage.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Search } from 'lucide-react';
+import TvShowGrid from '@/components/tv-shows/TvShowGrid';
+import { useTvShows } from '@/hooks/useTvShows';
+import { useAuth } from '@/hooks/useAuth';
+import type { TvSortBy, TvUserFilter } from '@/types/tv-show';
+
+const DEBOUNCE_MS = 400;
+
+const USER_FILTER_LABELS: Record<TvUserFilter, string> = {
+  rated: 'Rated by me',
+  watched: 'Watched by me',
+  reviewed: 'Reviewed by me',
+  commented: 'Commented by me',
+};
+
+export default function TvShowsPage() {
+  const { user } = useAuth();
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [sortBy, setSortBy] = useState<TvSortBy>('popularity');
+  const [userFilters, setUserFilters] = useState<TvUserFilter[]>([]);
+  const [page, setPage] = useState(1);
+  const [debounceTimer, setDebounceTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  const textSearch = debouncedSearch.trim() || undefined;
+
+  const { data, isLoading, isFetching } = useTvShows({
+    search: textSearch,
+    page,
+    sortBy,
+    userFilters,
+  });
+
+  const handleSearch = useCallback(
+    (value: string) => {
+      setSearchInput(value);
+      if (debounceTimer) clearTimeout(debounceTimer);
+      const timer = setTimeout(() => {
+        setDebouncedSearch(value);
+        setPage(1);
+      }, DEBOUNCE_MS);
+      setDebounceTimer(timer);
+    },
+    [debounceTimer]
+  );
+
+  const handleSortChange = (sort: TvSortBy) => {
+    setSortBy(sort);
+    setPage(1);
+  };
+
+  const handleFilterChange = (filter: TvUserFilter) => {
+    const isRemoving = userFilters.includes(filter);
+    setUserFilters(current =>
+      isRemoving ? current.filter(f => f !== filter) : [...current, filter]
+    );
+    if (isRemoving) {
+      if (filter === 'watched' && sortBy === 'watched_date') setSortBy('popularity');
+      if (filter === 'rated' && sortBy === 'my_rating') setSortBy('popularity');
+    }
+    setPage(1);
+  };
+
+  const totalPages = data?.total_pages ?? 1;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight">TV Shows</h1>
+        <p className="text-muted-foreground">Discover and track TV shows from TMDB</p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="search"
+              placeholder="Search TV shows by title…"
+              className="pl-9"
+              value={searchInput}
+              onChange={e => handleSearch(e.target.value)}
+            />
+          </div>
+
+          <Select value={sortBy} onValueChange={v => handleSortChange(v as TvSortBy)}>
+            <SelectTrigger className="w-full sm:w-48">
+              <SelectValue placeholder="Sort by" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="popularity">Most Popular</SelectItem>
+              <SelectItem value="rating">Highest Rated</SelectItem>
+              <SelectItem value="watched_date" disabled={!userFilters.includes('watched')}>
+                My Watched Date
+              </SelectItem>
+              <SelectItem value="my_rating" disabled={!userFilters.includes('rated')}>
+                My Highest Rated
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {user && (
+          <div className="flex flex-wrap gap-2">
+            {(Object.keys(USER_FILTER_LABELS) as TvUserFilter[]).map(filter => (
+              <Button
+                key={filter}
+                variant={userFilters.includes(filter) ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => handleFilterChange(filter)}>
+                {USER_FILTER_LABELS[filter]}
+              </Button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <TvShowGrid shows={data?.results ?? []} isLoading={isLoading || isFetching} />
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 pt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage(p => Math.max(1, p - 1))}
+            disabled={page === 1 || isFetching}>
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages || isFetching}>
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/services/tv-comments-api.ts
+++ b/packages/frontend/src/services/tv-comments-api.ts
@@ -1,0 +1,19 @@
+import { apiRequest } from './api-client';
+import type { TvComment } from '@/types/tv-show';
+
+export async function fetchTvComments(seriesId: string): Promise<TvComment[]> {
+  return apiRequest<TvComment[]>(`/api/tv/${seriesId}/comments`);
+}
+
+export async function createTvComment(seriesId: string, content: string): Promise<TvComment> {
+  return apiRequest<TvComment>(`/api/tv/${seriesId}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ content }),
+  });
+}
+
+export async function deleteTvComment(seriesId: string, commentId: number): Promise<void> {
+  return apiRequest<void>(`/api/tv/${seriesId}/comments/${commentId}`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/frontend/src/services/tv-shows-api.ts
+++ b/packages/frontend/src/services/tv-shows-api.ts
@@ -1,0 +1,35 @@
+import { apiRequest } from './api-client';
+import type {
+  TvShowListResponse,
+  TvShowDetail,
+  TvSeason,
+  TvSortBy,
+  TvUserFilter,
+} from '@/types/tv-show';
+
+export async function fetchTvShows(params: {
+  search?: string;
+  seriesId?: string;
+  page?: number;
+  sortBy?: TvSortBy;
+  userFilters?: TvUserFilter[];
+}): Promise<TvShowListResponse> {
+  const query = new URLSearchParams();
+  if (params.search) query.set('search', params.search);
+  if (params.seriesId !== undefined) query.set('series_id', params.seriesId);
+  if (params.page !== undefined) query.set('page', String(params.page));
+  if (params.sortBy) query.set('sort_by', params.sortBy);
+  if (params.userFilters && params.userFilters.length > 0) {
+    query.set('user_filter', params.userFilters.join(','));
+  }
+
+  return apiRequest<TvShowListResponse>(`/api/tv?${query.toString()}`);
+}
+
+export async function fetchTvShowDetail(seriesId: string): Promise<TvShowDetail> {
+  return apiRequest<TvShowDetail>(`/api/tv/${seriesId}`);
+}
+
+export async function fetchTvSeason(seriesId: string, seasonNumber: number): Promise<TvSeason> {
+  return apiRequest<TvSeason>(`/api/tv/${seriesId}/season/${seasonNumber}`);
+}

--- a/packages/frontend/src/services/user-tv-data-api.ts
+++ b/packages/frontend/src/services/user-tv-data-api.ts
@@ -1,0 +1,66 @@
+import { apiRequest } from './api-client';
+import type { UserTvData } from '@/types/tv-show';
+
+export async function fetchUserTvData(seriesId: string): Promise<UserTvData> {
+  return apiRequest<UserTvData>(`/api/tv/${seriesId}/user-data`);
+}
+
+export async function updateTvRating(seriesId: string, score: number): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/rating`, {
+    method: 'PUT',
+    body: JSON.stringify({ score }),
+  });
+}
+
+export async function removeTvRating(seriesId: string): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/rating`, { method: 'DELETE' });
+}
+
+export async function updateTvSeasonRating(
+  seriesId: string,
+  seasonNumber: number,
+  score: number
+): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/season/${seasonNumber}/rating`, {
+    method: 'PUT',
+    body: JSON.stringify({ score }),
+  });
+}
+
+export async function removeTvSeasonRating(seriesId: string, seasonNumber: number): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/season/${seasonNumber}/rating`, { method: 'DELETE' });
+}
+
+export async function updateTvReview(seriesId: string, content: string): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/review`, {
+    method: 'PUT',
+    body: JSON.stringify({ content }),
+  });
+}
+
+export async function removeTvReview(seriesId: string): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/review`, { method: 'DELETE' });
+}
+
+export async function markEpisodeWatched(
+  seriesId: string,
+  seasonNumber: number,
+  episodeNumber: number,
+  watchedAt: string
+): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/watch`, {
+    method: 'PUT',
+    body: JSON.stringify({ seasonNumber, episodeNumber, watchedAt }),
+  });
+}
+
+export async function unmarkEpisodeWatched(
+  seriesId: string,
+  seasonNumber: number,
+  episodeNumber: number
+): Promise<void> {
+  await apiRequest(`/api/tv/${seriesId}/watch`, {
+    method: 'DELETE',
+    body: JSON.stringify({ seasonNumber, episodeNumber }),
+  });
+}

--- a/packages/frontend/src/types/tv-show.ts
+++ b/packages/frontend/src/types/tv-show.ts
@@ -1,0 +1,84 @@
+export interface TvShowListItem {
+  seriesTmdbId: string;
+  name: string;
+  posterPath: string | null;
+  backdropPath: string | null;
+  voteAverage: number;
+  voteCount: number;
+  firstAirDate: string;
+  overview: string;
+}
+
+export interface ExternalTvRatings {
+  imdbId: string | null;
+  imdbRating: string | null;
+  rottenTomatoes: string | null;
+  metacritic: string | null;
+}
+
+export interface TvShowDetail extends TvShowListItem {
+  genres: { id: number; name: string }[];
+  numberOfSeasons: number;
+  numberOfEpisodes: number;
+  status: string;
+  networks: { id: number; name: string }[];
+  averageRuntime: number | null;
+  externalRatings: ExternalTvRatings;
+  tmdbUrl: string;
+  imdbUrl: string | null;
+  rtSearchUrl: string;
+}
+
+export interface TvEpisode {
+  episodeNumber: number;
+  name: string;
+  overview: string;
+  airDate: string | null;
+  runtime: number | null;
+  stillPath: string | null;
+}
+
+export interface TvSeason {
+  seasonNumber: number;
+  name: string;
+  overview: string;
+  posterPath: string | null;
+  airDate: string | null;
+  episodes: TvEpisode[];
+}
+
+export interface TvShowListResponse {
+  results: TvShowListItem[];
+  page: number;
+  total_pages: number;
+  total_results: number;
+}
+
+export interface UserTvWatchEntry {
+  seasonNumber: number;
+  episodeNumber: number;
+  watchedAt: string;
+}
+
+export interface UserTvData {
+  watchEntries: UserTvWatchEntry[];
+  showRating: { score: number } | null;
+  seasonRatings: Record<number, number>;
+  review: { content: string } | null;
+}
+
+export interface TvComment {
+  id: number;
+  seriesTmdbId: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  user: {
+    id: number;
+    username: string;
+  };
+}
+
+export type TvSortBy = 'popularity' | 'rating' | 'watched_date' | 'my_rating';
+
+export type TvUserFilter = 'rated' | 'watched' | 'reviewed' | 'commented';


### PR DESCRIPTION
# Plan: Introduce TV Shows

## TL;DR

Add full TV show support as a parallel domain alongside movies. New dedicated DB tables (no collision with movie tables), TMDB+OMDB data, episode-level watch tracking, season+show-level ratings, reviews and comments at show level. Separate /tv frontend routes. Extend Trakt import for TV.

---

## Decisions

- **Tracking granularity**: Episode-level watch tracking; season + show-level ratings; reviews + comments at show level
- **External data**: TMDB (primary) + OMDB (external ratings enrichment) — same pattern as movies
- **UI**: Separate `/tv` and `/tv/:seriesId` routes, separate pages/components
- **DB strategy**: New dedicated TV tables (no modifying existing movie tables) to avoid tmdbId namespace collision
- **Trakt import**: Extended to import TV show ratings and episode watch history
- **TvRating**: Use `seasonNumber = 0` as convention for show-level rating; non-nullable with unique `[seriesTmdbId, seasonNumber, userId]`

---

## Phase 1: Database Schema

Add 4 new Prisma models in `packages/backend/prisma/schema.prisma`:

1. **TvWatchEntry** — tracks individual episodes watched
   - `id`, `seriesTmdbId: String`, `seasonNumber: Int`, `episodeNumber: Int`, `userId`, `watchedAt`, `source`, `createdAt`
   - Unique: `[seriesTmdbId, seasonNumber, episodeNumber, userId]`
   - Cascade delete on User

2. **TvRating** — show-level (seasonNumber=0) or season-level rating
   - `id`, `seriesTmdbId: String`, `seasonNumber: Int (default 0)`, `userId`, `score: Int`, `source`, `ratedAt`, `createdAt`, `updatedAt`, `importedAt?`
   - Unique: `[seriesTmdbId, seasonNumber, userId]`
   - Cascade delete on User

3. **TvReview** — show-level review
   - `id`, `seriesTmdbId: String`, `userId`, `content: String`, `createdAt`, `updatedAt`
   - Unique: `[seriesTmdbId, userId]`
   - Cascade delete on User

4. **TvComment** — show-level comments
   - `id`, `seriesTmdbId: String`, `userId`, `content: String`, `createdAt`, `updatedAt`, `importedAt?`
   - Index on `seriesTmdbId`
   - Cascade delete on User

After schema changes: `cd packages/backend && npm run db:generate` + `npx prisma migrate dev --name add_tv_shows`

---

## Phase 2: Backend — TV Show Service Layer

New folder: `packages/backend/src/tv-shows/`

### tv-show-types.ts

- `TvShowListItem` — seriesTmdbId, name, posterPath, backdropPath, voteAverage, voteCount, firstAirDate, overview
- `TvShowDetail` — extends TvShowListItem + genres, number_of_seasons, number_of_episodes, externalRatings, status, networks, imdbId, urls
- `TvSeason` — seasonNumber, name, episodeCount, airDate, posterPath, episodes[]
- `TvEpisode` — episodeNumber, name, overview, airDate, runtime, stillPath
- `UserTvData` — watchEntries: TvWatchEntry[], showRating?, seasonRatings: Record<number, TvRating>, review?

### tv-show-service.ts

Analogous to `movie-service.ts`:

- `searchTvShows(query, page)` — TMDB `/search/tv`
- `discoverTvShows(sortBy, page)` — TMDB `/discover/tv`
- `getTvShowById(seriesTmdbId)` — TMDB `/tv/{id}` with external_ids appended
- `getTvShowDetails(seriesTmdbId)` — Full details + OMDB enrichment via IMDb ID (same pattern as `getMovieDetails`)
- `getTvSeason(seriesTmdbId, seasonNumber)` — TMDB `/tv/{id}/season/{n}` with episode list
- `mapTvListItem()` — transform TMDB result to TvShowListItem

### tv-watch-service.ts

- `markEpisodeWatched(seriesTmdbId, seasonNumber, episodeNumber, userId, watchedAt, source)` — upsert
- `unmarkEpisodeWatched(seriesTmdbId, seasonNumber, episodeNumber, userId)` — delete
- `getWatchEntriesForSeries(seriesTmdbId, userId)` — all episodes watched for a series
- `createWatchEntryIfMissing(...)` — for import deduplication

### tv-rating-service.ts

- `upsertTvRating(seriesTmdbId, seasonNumber=0, userId, score, ratedAt?, importedAt?, source)` — upsert
- `deleteTvRating(seriesTmdbId, seasonNumber, userId)` — delete
- `getTvRatingsForSeries(seriesTmdbId, userId)` — all ratings for a series (show + seasons)

### tv-review-service.ts

- `upsertTvReview(seriesTmdbId, userId, content)` — upsert
- `deleteTvReview(seriesTmdbId, userId)` — delete

### tv-comment-service.ts

- `getCommentsForSeries(seriesTmdbId)` — ordered by newest first, include user metadata
- `createComment(seriesTmdbId, userId, content, createdAt?, importedAt?)` — create
- `deleteComment(seriesTmdbId, commentId, userId)` — delete (validates ownership)

### tv-user-data-service.ts

- `getFilteredSeriesTmdbIds(userId, filters, sortBy?)` — same pattern as `getFilteredTmdbIds` in movie domain; queries TvRating, TvWatchEntry, TvReview, TvComment
- `getUserTvData(seriesTmdbId, userId)` — aggregated user data for a series

### tv-show-routes.ts

Routes under `/api/tv`:

| Method | Endpoint                                 | Auth     | Purpose                                                                 |
| ------ | ---------------------------------------- | -------- | ----------------------------------------------------------------------- |
| GET    | `/`                                      | —        | List/search TV shows (search, page, sort_by, user_filter)               |
| GET    | `/:seriesId`                             | —        | TV show details                                                         |
| GET    | `/:seriesId/season/:seasonNumber`        | optional | Season details + episode list                                           |
| GET    | `/:seriesId/user-data`                   | ✓        | User's ratings, review, watch entries                                   |
| GET    | `/:seriesId/comments`                    | —        | All show comments                                                       |
| POST   | `/:seriesId/comments`                    | ✓        | Create comment                                                          |
| DELETE | `/:seriesId/comments/:commentId`         | ✓        | Delete comment                                                          |
| PUT    | `/:seriesId/rating`                      | ✓        | Set show-level rating (seasonNumber=0)                                  |
| DELETE | `/:seriesId/rating`                      | ✓        | Remove show-level rating                                                |
| PUT    | `/:seriesId/season/:seasonNumber/rating` | ✓        | Set season rating                                                       |
| DELETE | `/:seriesId/season/:seasonNumber/rating` | ✓        | Remove season rating                                                    |
| PUT    | `/:seriesId/review`                      | ✓        | Create/update review                                                    |
| DELETE | `/:seriesId/review`                      | ✓        | Delete review                                                           |
| PUT    | `/:seriesId/watch`                       | ✓        | Mark episode watched: body `{ seasonNumber, episodeNumber, watchedAt }` |
| DELETE | `/:seriesId/watch`                       | ✓        | Unmark episode: body `{ seasonNumber, episodeNumber }`                  |

---

## Phase 3: Extend Trakt Import

Update `packages/backend/src/movies/import-service.ts`:

- In `importFromTrakt()`, add processing for:
  - `traktExport.ratings` entries where `type === 'show'` → upsert TvRating (seasonNumber=0) using `show.ids.tmdb`
  - `traktExport.history` entries where `type === 'episode'` → create TvWatchEntry using `show.ids.tmdb` + `episode.season` + `episode.number`
- Add `resolveTraktTvSeriesTmdbId(show)` helper — uses `show.ids.tmdb` directly (no IMDb lookup needed since Trakt provides TMDB IDs for TV)
- Update `TraktExport` type in `trakt.types.ts` to include TV-specific fields if not already present

---

## Phase 4: Register TV Routes

Update `packages/backend/src/index.ts`:

- Import `tvRoutes` from `tv-shows/tv-show-routes.ts`
- Register: `app.register(tvRoutes, { prefix: '/api/tv' })`

---

## Phase 5: Frontend — Types & Services

### types/tv-show.ts (new)

- `TvShowListItem`, `TvShowDetail`, `TvSeason`, `TvEpisode`
- `UserTvData` — showRating?, seasonRatings, watchedEpisodes: Set of "s{n}e{n}" keys, review?
- `TvSortBy` — 'popularity' | 'rating' | 'watched_date' | 'my_rating'
- `TvUserFilter` — 'rated' | 'watched' | 'reviewed' | 'commented'

### services/tv-shows-api.ts (new)

- `fetchTvShows(params)` — search, page, sort, filter
- `fetchTvShowDetail(seriesId)` — full show details
- `fetchTvSeason(seriesId, seasonNumber)` — season + episodes

### services/user-tv-data-api.ts (new)

- `fetchUserTvData(seriesId)` — get user data for show
- `updateTvRating(seriesId, score)` / `removeTvRating(seriesId)` — show-level
- `updateTvSeasonRating(seriesId, seasonNumber, score)` / `removeTvSeasonRating(seriesId, seasonNumber)` — season-level
- `updateTvReview(seriesId, content)` / `removeTvReview(seriesId)`
- `markEpisodeWatched(seriesId, seasonNumber, episodeNumber, watchedAt)` / `unmarkEpisodeWatched(...)`

### services/tv-comments-api.ts (new)

- `fetchTvComments(seriesId)` / `createTvComment(seriesId, content)` / `deleteTvComment(seriesId, commentId)`

---

## Phase 6: Frontend Hooks

- `hooks/useTvShows.ts` — React Query wrapper for `fetchTvShows`, cache key `['tv-shows', params]`, 5-min stale
- `hooks/useTvShowDetails.ts` — dual queries: show details (10-min cache) + user data (0 stale, auth-gated)
- `hooks/useTvSeason.ts` — season details query, cache key `['tv-season', seriesId, seasonNumber]`
- `hooks/useUserTvData.ts` — mutations for all ratings/review/watch actions with toast feedback + cache invalidation
- `hooks/useTvComments.ts` — comments query + add/remove mutations

---

## Phase 7: Frontend Components

New folder: `packages/frontend/src/components/tv-shows/`

- `TvShowCard.tsx` — mirrors MovieCard; shows poster, name, year, TMDB rating; links to `/tv/:seriesId`
- `TvShowGrid.tsx` — mirrors MovieGrid; responsive grid, skeleton loading
- `EpisodeRow.tsx` — episode number, name, air date, runtime, watch toggle button; shows "watched" state
- `SeasonSection.tsx` — collapsible season header (poster, name, episode count, season rating stars), renders EpisodeRow list

---

## Phase 8: Frontend Pages

### pages/tv-shows/TvShowsPage.tsx (new)

- Mirrors MoviesPage: search, sort, filter, pagination
- Uses TvShowGrid + TvShowCard
- Separate sort options: popularity, rating (no watched_date/my_rating unless filter active)

### pages/tv-show-details/TvShowDetailsPage.tsx (new)

- Hero section: backdrop, poster, title, status, genres, first air date, network
- External ratings badges (TMDB, IMDB, RT) — same pattern as MovieDetailsPage
- Show-level: watch (overall progress info), rating (StarRating), review textarea
- Comments section — same as movie details
- Seasons list: SeasonSection components with EpisodeRow children
  - Season-level star rating
  - Episode-level watch toggles

---

## Phase 9: Routing & Navigation

- Update `packages/frontend/src/App.tsx`: add routes `/tv` → TvShowsPage and `/tv/:seriesId` → TvShowDetailsPage
- Update `packages/frontend/src/components/layout/Header.tsx`: add "TV Shows" nav link alongside "Movies"

---

## Relevant Files (to create or modify)

**Create (Backend):**

- `packages/backend/src/tv-shows/tv-show-types.ts`
- `packages/backend/src/tv-shows/tv-show-service.ts`
- `packages/backend/src/tv-shows/tv-watch-service.ts`
- `packages/backend/src/tv-shows/tv-rating-service.ts`
- `packages/backend/src/tv-shows/tv-review-service.ts`
- `packages/backend/src/tv-shows/tv-comment-service.ts`
- `packages/backend/src/tv-shows/tv-user-data-service.ts`
- `packages/backend/src/tv-shows/tv-show-routes.ts`

**Modify (Backend):**

- `packages/backend/prisma/schema.prisma` — add 4 new models
- `packages/backend/src/movies/import-service.ts` — extend Trakt importer for TV
- `packages/backend/src/trakt.types.ts` — add TV-specific Trakt export types if missing
- `packages/backend/src/index.ts` — register TV routes

**Create (Frontend):**

- `packages/frontend/src/types/tv-show.ts`
- `packages/frontend/src/services/tv-shows-api.ts`
- `packages/frontend/src/services/user-tv-data-api.ts`
- `packages/frontend/src/services/tv-comments-api.ts`
- `packages/frontend/src/hooks/useTvShows.ts`
- `packages/frontend/src/hooks/useTvShowDetails.ts`
- `packages/frontend/src/hooks/useTvSeason.ts`
- `packages/frontend/src/hooks/useUserTvData.ts`
- `packages/frontend/src/hooks/useTvComments.ts`
- `packages/frontend/src/components/tv-shows/TvShowCard.tsx`
- `packages/frontend/src/components/tv-shows/TvShowGrid.tsx`
- `packages/frontend/src/components/tv-shows/EpisodeRow.tsx`
- `packages/frontend/src/components/tv-shows/SeasonSection.tsx`
- `packages/frontend/src/pages/tv-shows/TvShowsPage.tsx`
- `packages/frontend/src/pages/tv-show-details/TvShowDetailsPage.tsx`

**Modify (Frontend):**

- `packages/frontend/src/App.tsx` — add `/tv` and `/tv/:seriesId` routes
- `packages/frontend/src/components/layout/Header.tsx` — add TV Shows nav link

---

## Verification

1. `cd packages/backend && npx prisma migrate dev --name add_tv_shows` — apply new schema
2. `cd packages/backend && npm run db:generate` — regenerate Prisma client
3. `npm run build` from workspace root — verify TypeScript compilation across both packages
4. `npm run lint` — verify no lint errors
5. `npm test` — ensure existing movie tests still pass
6. Manual: search for a TV show (e.g., "Breaking Bad"), view detail page, mark episodes as watched, set a season rating, leave a comment
7. Manual: import a Trakt export that includes TV show ratings and episode history, verify data appears correctly

---

## Explicitly Out of Scope

- Per-episode ratings (only show + season level)
- Reviews/comments at season or episode level (show level only)
- Filmtipset import for TV (Filmtipset is a movie-only site)
- Push notifications for new episodes
- "Continue watching" / progress tracking UI