### PR TITLE
feat: add Flexget list integration and sync item deletions #24

### DIFF
--- a/docs/flexget_swagger.json
+++ b/docs/flexget_swagger.json
@@ -1,0 +1,10352 @@
+{
+    "swagger": "2.0",
+    "basePath": "/api",
+    "paths": {
+        "/auth/login/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Login successful",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Login with username and password",
+                "operationId": "post_login_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/auth.login"
+                        },
+                        "description": "Username and Password"
+                    }
+                ],
+                "tags": [
+                    "auth"
+                ]
+            }
+        },
+        "/auth/logout/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Logout successful",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Logout and clear session cookies",
+                "operationId": "post_logout_api",
+                "tags": [
+                    "auth"
+                ]
+            }
+        },
+        "/cached/": {
+            "get": {
+                "responses": {
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Cached resource"
+                    }
+                },
+                "summary": "Cache remote resources",
+                "description": "Returns a cached copy of the requested resource, matching its mime type",
+                "operationId": "get_cached_resource",
+                "parameters": [
+                    {
+                        "name": "url",
+                        "in": "query",
+                        "type": "string",
+                        "required": true,
+                        "description": "URL to cache"
+                    },
+                    {
+                        "name": "force",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Force fetching remote resource",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "cached"
+                ]
+            }
+        },
+        "/database/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Perform DB operations",
+                "operationId": "post_db_operation",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/db_schema"
+                        }
+                    }
+                ],
+                "tags": [
+                    "database"
+                ]
+            }
+        },
+        "/database/plugins/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/plugins_list"
+                        }
+                    }
+                },
+                "summary": "List resettable DB plugins",
+                "operationId": "get_db_cleanup",
+                "tags": [
+                    "database"
+                ]
+            }
+        },
+        "/entry_list/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved entry lists",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list_return_lists_schema"
+                        }
+                    }
+                },
+                "summary": "Get entry lists",
+                "operationId": "get_entry_list_lists_api",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter results by list name"
+                    }
+                ],
+                "tags": [
+                    "entry_list"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list_object_schema"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Create a new entry list",
+                "operationId": "post_entry_list_lists_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list_input_object_schema"
+                        }
+                    }
+                ],
+                "tags": [
+                    "entry_list"
+                ]
+            }
+        },
+        "/entry_list/{list_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "list successfully deleted",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete list by ID",
+                "operationId": "delete_entry_list_list_api",
+                "tags": [
+                    "entry_list"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list_object_schema"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Get list by ID",
+                "operationId": "get_entry_list_list_api",
+                "tags": [
+                    "entry_list"
+                ]
+            }
+        },
+        "/entry_list/{list_id}/entries/": {
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/entry_lists_entries_return_schema"
+                        }
+                    }
+                },
+                "summary": "Get entries by list ID",
+                "operationId": "get_entry_list_entries_api",
+                "parameters": [
+                    {
+                        "name": "list_id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer",
+                        "description": "ID of the list"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "title",
+                        "enum": [
+                            "id",
+                            "added",
+                            "title",
+                            "original_url",
+                            "list_id"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "entry_list"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Successfully created entry object",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list_entry_base_schema"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Create a new entry object",
+                "operationId": "post_entry_list_entries_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/base_entry_schema"
+                        }
+                    },
+                    {
+                        "name": "list_id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "tags": [
+                    "entry_list"
+                ]
+            }
+        },
+        "/entry_list/{list_id}/entries/batch": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "204": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Remove multiple entries",
+                "description": "Remove multiple entries",
+                "operationId": "delete_entry_list_entries_batch_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list.batch_remove_object"
+                        }
+                    }
+                ],
+                "tags": [
+                    "entry_list"
+                ]
+            }
+        },
+        "/entry_list/{list_id}/entries/{entry_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "ID of the entry",
+                    "name": "entry_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete an entry by list ID and entry ID",
+                "operationId": "delete_entry_list_entry_api",
+                "tags": [
+                    "entry_list"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list_entry_base_schema"
+                        }
+                    }
+                },
+                "summary": "Get an entry by list ID and entry ID",
+                "operationId": "get_entry_list_entry_api",
+                "tags": [
+                    "entry_list"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/entry_list_entry_base_schema"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Set entry object's entry data",
+                "description": "Sent entry data will override any existing entry data the existed before",
+                "operationId": "put_entry_list_entry_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/base_entry_schema"
+                        }
+                    }
+                ],
+                "tags": [
+                    "entry_list"
+                ]
+            }
+        },
+        "/failed/": {
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "successfully deleted failed entry",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Clear all failed entries",
+                "operationId": "delete_retry_failed",
+                "tags": [
+                    "failed"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/retry_entries_list_schema"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "List all failed entries",
+                "operationId": "get_retry_failed",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "failure_time",
+                        "enum": [
+                            "failure_time",
+                            "id",
+                            "title",
+                            "url",
+                            "reason",
+                            "count",
+                            "retry_time"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "failed"
+                ]
+            }
+        },
+        "/failed/{failed_entry_id}/": {
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "successfully delete failed entry",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete failed entry by ID",
+                "operationId": "delete_retry_failed_id",
+                "parameters": [
+                    {
+                        "name": "failed_entry_id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "tags": [
+                    "failed"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/retry_failed_entry_schema"
+                        }
+                    }
+                },
+                "summary": "Get failed entry by ID",
+                "operationId": "get_retry_failed_id",
+                "parameters": [
+                    {
+                        "name": "failed_entry_id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer",
+                        "description": "ID of the failed entry"
+                    }
+                ],
+                "tags": [
+                    "failed"
+                ]
+            }
+        },
+        "/history/": {
+            "parameters": [
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "time",
+                    "enum": [
+                        "id",
+                        "task",
+                        "filename",
+                        "url",
+                        "title",
+                        "time",
+                        "details"
+                    ]
+                },
+                {
+                    "name": "task",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Filter by task name"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/history.list"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "List of previously accepted entries",
+                "operationId": "get_history_api",
+                "tags": [
+                    "history"
+                ]
+            }
+        },
+        "/imdb/search/{title}/": {
+            "parameters": [
+                {
+                    "description": "Movie name or IMDB ID",
+                    "name": "title",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/imdb_search_schema"
+                        }
+                    }
+                },
+                "summary": "Get a list of IMDB search result by name or ID",
+                "operationId": "get_imdb_movie_search",
+                "tags": [
+                    "imdb"
+                ]
+            }
+        },
+        "/inject/": {
+            "post": {
+                "responses": {
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/task.execution"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Execute task and stream results",
+                "description": "For details on available parameters query /params/ endpoint",
+                "operationId": "post_task_execution_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/task_execution_input"
+                        }
+                    }
+                ],
+                "tags": [
+                    "inject"
+                ]
+            }
+        },
+        "/inject/params/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.execution_params"
+                        }
+                    }
+                },
+                "summary": "Execute payload parameters",
+                "description": "Available payload parameters for task execute",
+                "operationId": "get_task_execution_params",
+                "tags": [
+                    "inject"
+                ]
+            }
+        },
+        "/irc/connections/": {
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Name of connection. Leave empty to apply to all connections."
+                }
+            ],
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/irc.connections"
+                        }
+                    }
+                },
+                "summary": "Return status of IRC connections",
+                "operationId": "get_irc_status",
+                "tags": [
+                    "irc"
+                ]
+            }
+        },
+        "/irc/connections/enums/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/empty"
+                        }
+                    }
+                },
+                "summary": "Get channel status enumeration meaning",
+                "operationId": "get_irc_enums",
+                "tags": [
+                    "irc"
+                ]
+            }
+        },
+        "/irc/restart/": {
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Name of connection. Leave empty to apply to all connections."
+                }
+            ],
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Restarts IRC connections",
+                "operationId": "get_irc_restart",
+                "tags": [
+                    "irc"
+                ]
+            }
+        },
+        "/irc/stop/": {
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Name of connection. Leave empty to apply to all connections."
+                },
+                {
+                    "name": "wait",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Wait for connection to exit gracefully",
+                    "default": false
+                }
+            ],
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Stop IRC connections",
+                "operationId": "get_irc_stop",
+                "tags": [
+                    "irc"
+                ]
+            }
+        },
+        "/movie_list/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/return_lists"
+                        }
+                    }
+                },
+                "summary": "Get movies lists",
+                "operationId": "get_movie_list_api",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter results by list name"
+                    }
+                ],
+                "tags": [
+                    "movie_list"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/list_object"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Create a new list",
+                "operationId": "post_movie_list_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/new_list"
+                        }
+                    }
+                ],
+                "tags": [
+                    "movie_list"
+                ]
+            }
+        },
+        "/movie_list/identifiers/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/movie_list.identifiers"
+                        }
+                    }
+                },
+                "summary": "Return a list of supported movie list identifiers",
+                "description": "A list of valid movie identifiers to be used when creating or editing movie",
+                "operationId": "get_movie_list_identifiers",
+                "tags": [
+                    "movie_list"
+                ]
+            }
+        },
+        "/movie_list/{list_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Success"
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete list by ID",
+                "operationId": "delete_movie_list_list_api",
+                "tags": [
+                    "movie_list"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/list_object"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Get list by ID",
+                "operationId": "get_movie_list_list_api",
+                "tags": [
+                    "movie_list"
+                ]
+            }
+        },
+        "/movie_list/{list_id}/movies/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/return_movies"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Get movies by list ID",
+                "operationId": "get_movie_list_movies_api",
+                "parameters": [
+                    {
+                        "name": "list_id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer",
+                        "description": "ID of the list"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "title",
+                        "enum": [
+                            "id",
+                            "added",
+                            "title",
+                            "year"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "movie_list"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/movie_list_object"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Add movies to list by ID",
+                "operationId": "post_movie_list_movies_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/input_movie_entry"
+                        },
+                        "description": "Use movie identifier using the following format:\n[{'ID_NAME: 'ID_VALUE'}]."
+                    },
+                    {
+                        "name": "list_id",
+                        "in": "path",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "tags": [
+                    "movie_list"
+                ]
+            }
+        },
+        "/movie_list/{list_id}/movies/batch": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "204": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Remove multiple entries",
+                "description": "Remove multiple entries",
+                "operationId": "delete_movie_list_entries_batch_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/movie_list.batch_remove_object"
+                        }
+                    }
+                ],
+                "tags": [
+                    "movie_list"
+                ]
+            }
+        },
+        "/movie_list/{list_id}/movies/{movie_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "ID of the movie",
+                    "name": "movie_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete a movie by list ID and movie ID",
+                "operationId": "delete_movie_list_movie_api",
+                "tags": [
+                    "movie_list"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/movie_list_object"
+                        }
+                    }
+                },
+                "summary": "Get a movie by list ID and movie ID",
+                "operationId": "get_movie_list_movie_api",
+                "tags": [
+                    "movie_list"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/movie_list_object"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Set movie identifiers",
+                "description": "Sent movie identifiers will override any existing identifiers that the movie currently holds",
+                "operationId": "put_movie_list_movie_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/input_movie_list_id_object"
+                        },
+                        "description": "Use movie identifier using the following format:\n[{'ID_NAME: 'ID_VALUE'}]."
+                    }
+                ],
+                "tags": [
+                    "movie_list"
+                ]
+            }
+        },
+        "/pending/": {
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete pending entries",
+                "operationId": "delete_pending_entries_api",
+                "parameters": [
+                    {
+                        "name": "task_name",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter by task name"
+                    },
+                    {
+                        "name": "approved",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter by approval status"
+                    }
+                ],
+                "tags": [
+                    "pending"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending.entry_list"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "List all pending entries",
+                "operationId": "get_pending_entries_api",
+                "parameters": [
+                    {
+                        "name": "task_name",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter by task name"
+                    },
+                    {
+                        "name": "approved",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter by approval status"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "added",
+                        "enum": [
+                            "added",
+                            "task_name",
+                            "title",
+                            "url",
+                            "approved"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "pending"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "204": {
+                        "description": "No entries modified"
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending.entry_list"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Approve/Reject the status of pending entries",
+                "operationId": "put_pending_entries_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/pending.operation"
+                        },
+                        "description": "Either 'approve' or 'reject'"
+                    }
+                ],
+                "tags": [
+                    "pending"
+                ]
+            }
+        },
+        "/pending/{entry_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the entry",
+                    "name": "entry_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete a pending entry",
+                "operationId": "delete_pending_entry_api",
+                "tags": [
+                    "pending"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending.entry"
+                        }
+                    }
+                },
+                "summary": "Get a pending entry by ID",
+                "operationId": "get_pending_entry_api",
+                "tags": [
+                    "pending"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending.entry"
+                        }
+                    }
+                },
+                "summary": "Approve/Reject the status of a pending entry",
+                "operationId": "put_pending_entry_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/pending.operation"
+                        },
+                        "description": "Either 'approve' or 'reject'"
+                    }
+                ],
+                "tags": [
+                    "pending"
+                ]
+            }
+        },
+        "/pending_list/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved pending lists",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.return_lists"
+                        }
+                    }
+                },
+                "summary": "Get pending lists",
+                "operationId": "get_pending_list_lists_api",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter results by list name"
+                    }
+                ],
+                "tags": [
+                    "pending_list"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.return_list"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Create a new pending list",
+                "operationId": "post_pending_list_lists_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.input_list"
+                        }
+                    }
+                ],
+                "tags": [
+                    "pending_list"
+                ]
+            }
+        },
+        "/pending_list/{list_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "list successfully deleted",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete pending list by ID",
+                "operationId": "delete_pending_list_list_api",
+                "tags": [
+                    "pending_list"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.return_list"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Get pending list by ID",
+                "operationId": "get_pending_list_list_api",
+                "tags": [
+                    "pending_list"
+                ]
+            }
+        },
+        "/pending_list/{list_id}/entries/": {
+            "parameters": [
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "title",
+                    "enum": [
+                        "id",
+                        "added",
+                        "title",
+                        "original_url",
+                        "list_id",
+                        "approved"
+                    ]
+                },
+                {
+                    "name": "filter",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Filter by title name"
+                },
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.entry_return_schema"
+                        }
+                    }
+                },
+                "summary": "Get entries by list ID",
+                "operationId": "get_pending_list_entries_api",
+                "tags": [
+                    "pending_list"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Successfully created entry object",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.entry_base_schema"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Create a new entry object",
+                "operationId": "post_pending_list_entries_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/base_entry_schema"
+                        }
+                    }
+                ],
+                "tags": [
+                    "pending_list"
+                ]
+            }
+        },
+        "/pending_list/{list_id}/entries/batch": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "204": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Remove multiple entries",
+                "description": "Remove multiple entries",
+                "operationId": "delete_pending_list_entries_batch_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.batch_remove_object"
+                        }
+                    }
+                ],
+                "tags": [
+                    "pending_list"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.entry_return_schema"
+                        }
+                    }
+                },
+                "summary": "Perform operations on multiple entries",
+                "description": "Approve and reject multiple entries",
+                "operationId": "put_pending_list_entries_batch_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.batch_operation_object"
+                        }
+                    }
+                ],
+                "tags": [
+                    "pending_list"
+                ]
+            }
+        },
+        "/pending_list/{list_id}/entries/{entry_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the list",
+                    "name": "list_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "ID of the entry",
+                    "name": "entry_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete an entry by list ID and entry ID",
+                "operationId": "delete_pending_list_entry_api",
+                "tags": [
+                    "pending_list"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.entry_base_schema"
+                        }
+                    }
+                },
+                "summary": "Get an entry by list ID and entry ID",
+                "operationId": "get_pending_list_entry_api",
+                "tags": [
+                    "pending_list"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.entry_base_schema"
+                        }
+                    }
+                },
+                "summary": "Set entry object's pending status",
+                "description": "Approve or reject an entry's status",
+                "operationId": "put_pending_list_entry_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/pending_list.operation_schema"
+                        }
+                    }
+                ],
+                "tags": [
+                    "pending_list"
+                ]
+            }
+        },
+        "/plugins/": {
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/plugin_list_reply"
+                        }
+                    }
+                },
+                "summary": "Get list of registered plugins",
+                "operationId": "get_plugins_api",
+                "parameters": [
+                    {
+                        "name": "include_schema",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include plugin schema. This will increase response size",
+                        "default": false
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "interface",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Show plugins which implement this interface"
+                    },
+                    {
+                        "name": "phase",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Show plugins that act on this phase"
+                    }
+                ],
+                "tags": [
+                    "plugins"
+                ]
+            }
+        },
+        "/plugins/{plugin_name}/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/plugin_object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Return plugin data by name",
+                "operationId": "get_plugin_api",
+                "parameters": [
+                    {
+                        "name": "plugin_name",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "Name of the plugin to return"
+                    },
+                    {
+                        "name": "include_schema",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include plugin schema. This will increase response size",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "plugins"
+                ]
+            }
+        },
+        "/rejected/": {
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Clear all rejected entries",
+                "operationId": "delete_rejected",
+                "tags": [
+                    "rejected"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/rejected_entries_list_schema"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "List all rejected entries",
+                "operationId": "get_rejected",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "added",
+                        "enum": [
+                            "added",
+                            "id",
+                            "title",
+                            "url",
+                            "expires",
+                            "rejected_by",
+                            "reason"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "rejected"
+                ]
+            }
+        },
+        "/rejected/{rejected_entry_id}/": {
+            "parameters": [
+                {
+                    "name": "rejected_entry_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete a rejected entry",
+                "operationId": "delete_rejected_entry",
+                "tags": [
+                    "rejected"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/rejected_failed_entry_schema"
+                        }
+                    }
+                },
+                "summary": "Return a rejected entry",
+                "operationId": "get_rejected_entry",
+                "tags": [
+                    "rejected"
+                ]
+            }
+        },
+        "/schedules/": {
+            "get": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/schedules.list"
+                        }
+                    }
+                },
+                "summary": "List schedules",
+                "description": "Schedule ID changes upon daemon restart. The schedules object supports either interval or schedule (cron) objects, see the model definition for details. Tasks also support string or list (Not displayed as Swagger does yet not support anyOf or oneOf.",
+                "operationId": "get_schedules_api",
+                "tags": [
+                    "schedules"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/schedules.schedule"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Add new schedule",
+                "description": "Schedule ID changes upon daemon restart. The schedules object supports either interval or schedule (cron) objects, see the model definition for details. Tasks also support string or list (Not displayed as Swagger does yet not support anyOf or oneOf.",
+                "operationId": "post_schedules_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/schedules.base"
+                        },
+                        "description": "Schedule Object"
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ]
+            }
+        },
+        "/schedules/{schedule_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of Schedule",
+                    "name": "schedule_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Schedule deleted",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete a schedule",
+                "description": "Schedule ID changes upon daemon restart. The schedules object supports either interval or schedule (cron) objects, see the model definition for details. Tasks also support string or list (Not displayed as Swagger does yet not support anyOf or oneOf.",
+                "operationId": "delete_schedule_api",
+                "tags": [
+                    "schedules"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/schedules.schedule"
+                        }
+                    }
+                },
+                "summary": "Get schedule details",
+                "description": "Schedule ID changes upon daemon restart. The schedules object supports either interval or schedule (cron) objects, see the model definition for details. Tasks also support string or list (Not displayed as Swagger does yet not support anyOf or oneOf.",
+                "operationId": "get_schedule_api",
+                "tags": [
+                    "schedules"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/schedules.schedule"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Update schedule",
+                "description": "Schedule ID changes upon daemon restart. The schedules object supports either interval or schedule (cron) objects, see the model definition for details. Tasks also support string or list (Not displayed as Swagger does yet not support anyOf or oneOf.",
+                "operationId": "put_schedule_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/schedules.base"
+                        },
+                        "description": "Updated Schedule Object"
+                    }
+                ],
+                "tags": [
+                    "schedules"
+                ]
+            }
+        },
+        "/schema/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/schema.list"
+                        }
+                    }
+                },
+                "summary": "List all schema definitions",
+                "operationId": "get_schema_all_api",
+                "tags": [
+                    "schema"
+                ]
+            }
+        },
+        "/schema/{path}/": {
+            "parameters": [
+                {
+                    "description": "Path of schema",
+                    "name": "path",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/schema.list"
+                        }
+                    }
+                },
+                "summary": "Get schema definition",
+                "operationId": "get_schema_api",
+                "tags": [
+                    "schema"
+                ]
+            }
+        },
+        "/seen/": {
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Successfully delete all entries",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete seen entries",
+                "description": "Delete seen entries",
+                "operationId": "delete_seen_search_api",
+                "parameters": [
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter by any field value or leave empty to get all entries"
+                    },
+                    {
+                        "name": "local",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter results by seen locality."
+                    }
+                ],
+                "tags": [
+                    "seen"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved seen objects",
+                        "schema": {
+                            "$ref": "#/definitions/seen_search_schema"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Search for seen entries",
+                "description": "Get seen entries",
+                "operationId": "get_seen_search_api",
+                "parameters": [
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter by any field value or leave empty to get all entries"
+                    },
+                    {
+                        "name": "local",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter results by seen locality."
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "title",
+                        "enum": [
+                            "title",
+                            "task",
+                            "added",
+                            "local",
+                            "reason",
+                            "id"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "seen"
+                ]
+            }
+        },
+        "/seen/{seen_entry_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of seen entry",
+                    "name": "seen_entry_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully deleted entry",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete seen entry by ID",
+                "operationId": "delete_seen_search_idapi",
+                "tags": [
+                    "seen"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/seen_object_schema"
+                        }
+                    }
+                },
+                "summary": "Get seen entry by ID",
+                "operationId": "get_seen_search_idapi",
+                "tags": [
+                    "seen"
+                ]
+            }
+        },
+        "/series/": {
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Series list retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/list_series"
+                        }
+                    }
+                },
+                "summary": "List existing shows",
+                "description": "Get a  list of Flexget's shows in DB",
+                "operationId": "get_series_api",
+                "parameters": [
+                    {
+                        "name": "begin",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Show series begin episode",
+                        "default": true
+                    },
+                    {
+                        "name": "latest",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Show series latest downloaded episode and release",
+                        "default": true
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "show_name",
+                        "enum": [
+                            "show_name",
+                            "last_download_date"
+                        ]
+                    },
+                    {
+                        "name": "in_config",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Filter list if shows are currently in configuration.",
+                        "default": "configured",
+                        "enum": [
+                            "configured",
+                            "unconfigured",
+                            "all"
+                        ]
+                    },
+                    {
+                        "name": "premieres",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter by downloaded premieres only.",
+                        "default": false
+                    },
+                    {
+                        "name": "lookup",
+                        "in": "query",
+                        "type": "array",
+                        "description": "Get lookup result for every show by sending another request to lookup API",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "enum": [
+                            "tvdb",
+                            "tvmaze"
+                        ]
+                    },
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Search by name based on the query"
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/show_details"
+                        }
+                    }
+                },
+                "summary": "Create a new show and set its first accepted episode and/or alternate names",
+                "operationId": "post_series_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/series_input_schema"
+                        },
+                        "description": "'episode_identifier' should be one of SxxExx, integer or date formatted such as 2012-12-12"
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/search/{name}/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Show list retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/list_series"
+                        }
+                    }
+                },
+                "summary": "List of shows matching lookup name",
+                "description": "Searches for a show in the DB via its name. Returns a list of matching shows.",
+                "operationId": "get_series_get_shows_api",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "Name of the show(s) to search"
+                    },
+                    {
+                        "name": "begin",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Show series begin episode",
+                        "default": true
+                    },
+                    {
+                        "name": "latest",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Show series latest downloaded episode and release",
+                        "default": true
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Removed series from DB",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Remove series from DB",
+                "description": "Delete a specific show using its ID",
+                "operationId": "delete_series_show_api",
+                "parameters": [
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will fire a 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Show information retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/show_details"
+                        }
+                    }
+                },
+                "summary": "Get show details by ID",
+                "description": "Get a specific show using its ID",
+                "operationId": "get_series_show_api",
+                "parameters": [
+                    {
+                        "name": "begin",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Show series begin episode",
+                        "default": true
+                    },
+                    {
+                        "name": "latest",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Show series latest downloaded episode and release",
+                        "default": true
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Episodes for series will be accepted starting with ep_id",
+                        "schema": {
+                            "$ref": "#/definitions/show_details"
+                        }
+                    }
+                },
+                "summary": "Set the initial episode of an existing show",
+                "description": "Set a begin episode or alternate names using a show ID. Note that alternate names override the existing names (if name does not belong to a different show).",
+                "operationId": "put_series_show_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/series_edit_schema"
+                        },
+                        "description": "'episode_identifier' should be one of SxxExx, integer or date formatted such as 2012-12-12"
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/episodes/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully forgotten all episodes from show",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete all episodes of a show",
+                "description": "The 'Series-ID' header will be appended to the result headers\nDelete all show episodes via its ID. Deleting an episode will mark it as wanted again",
+                "operationId": "delete_series_episodes_api",
+                "parameters": [
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will fire a 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Episodes retrieved successfully for show",
+                        "schema": {
+                            "$ref": "#/definitions/episode_list"
+                        }
+                    }
+                },
+                "summary": "Get episodes by show ID",
+                "description": "The 'Series-ID' header will be appended to the result headers\nGet all show episodes via its ID",
+                "operationId": "get_series_episodes_api",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/episodes/{ep_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Episode ID",
+                    "name": "ep_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Episode successfully forgotten for show",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Forgets episode by show ID and episode ID",
+                "description": "Delete a specific episode via its ID and show ID. Deleting an episode will mark it as wanted again",
+                "operationId": "delete_series_episode_api",
+                "parameters": [
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will fire a 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Episode retrieved successfully for show",
+                        "schema": {
+                            "$ref": "#/definitions/episode_item"
+                        }
+                    }
+                },
+                "summary": "Get episode by show ID and episode ID",
+                "description": "Get a specific episode via its ID and show ID",
+                "operationId": "get_series_episode_api",
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/episodes/{ep_id}/releases/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Episode ID",
+                    "name": "ep_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully deleted all releases for episode",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete all episodes releases by show ID and episode ID",
+                "description": "Releases are any seen entries that match the episode. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Episode-ID' header will be appended to the result headers.\nDelete all releases for a specific episode of a specific show.",
+                "operationId": "delete_series_episode_releases_api",
+                "parameters": [
+                    {
+                        "name": "downloaded",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter between release status"
+                    },
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will for 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Releases retrieved successfully for episode",
+                        "schema": {
+                            "$ref": "#/definitions/release_list_schema"
+                        }
+                    }
+                },
+                "summary": "Get all episodes releases by show ID and episode ID",
+                "description": "Releases are any seen entries that match the episode. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Episode-ID' header will be appended to the result headers.\nGet all matching releases for a specific episode of a specific show.",
+                "operationId": "get_series_episode_releases_api",
+                "parameters": [
+                    {
+                        "name": "downloaded",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter between release status"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "first_seen",
+                        "enum": [
+                            "first_seen",
+                            "downloaded",
+                            "proper_count",
+                            "title"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully reset all downloaded releases for episode",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Mark all downloaded releases as not downloaded",
+                "description": "Releases are any seen entries that match the episode. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Episode-ID' header will be appended to the result headers.\nResets all of the downloaded releases of an episode, clearing the quality to be downloaded again,",
+                "operationId": "put_series_episode_releases_api",
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/episodes/{ep_id}/releases/{rel_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Episode ID",
+                    "name": "ep_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Release ID",
+                    "name": "rel_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Release successfully deleted",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete episode release by show ID, episode ID and release ID",
+                "description": "Releases are any seen entries that match the episode. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Episode-ID' header will be appended to the result headers.\nDelete a specific releases for a specific episode of a specific show.",
+                "operationId": "delete_series_episode_release_api",
+                "parameters": [
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will fire a 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Release retrieved successfully for episode",
+                        "schema": {
+                            "$ref": "#/definitions/release_schema"
+                        }
+                    }
+                },
+                "summary": "Get episode release by show ID, episode ID and release ID",
+                "description": "Releases are any seen entries that match the episode. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Episode-ID' header will be appended to the result headers.\nGet a specific downloaded release for a specific episode of a specific show",
+                "operationId": "get_series_episode_release_api",
+                "tags": [
+                    "series"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully reset downloaded release status",
+                        "schema": {
+                            "$ref": "#/definitions/release_schema"
+                        }
+                    }
+                },
+                "summary": "Reset a downloaded release status",
+                "description": "Releases are any seen entries that match the episode. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Episode-ID' header will be appended to the result headers.\nResets the downloaded release status, clearing the quality to be downloaded again",
+                "operationId": "put_series_episode_release_api",
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/seasons/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully forgotten all seasons from show",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete all seasons of a show",
+                "description": "The 'Series-ID' header will be appended to the result headers\nDelete all show seasons via its ID. Deleting a season will mark it as wanted again",
+                "operationId": "delete_series_seasons_api",
+                "parameters": [
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will fire a 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Seasons retrieved successfully for show",
+                        "schema": {
+                            "$ref": "#/definitions/season_list"
+                        }
+                    }
+                },
+                "summary": "Get seasons by show ID",
+                "description": "The 'Series-ID' header will be appended to the result headers\nGet all show seasons via its ID",
+                "operationId": "get_series_seasons_api",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/seasons/{season_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Season ID",
+                    "name": "season_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Season successfully forgotten for show",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Forgets season by show ID and season ID",
+                "description": "Delete a specific season via its ID and show ID. Deleting a season will mark it as wanted again",
+                "operationId": "delete_series_season_api",
+                "parameters": [
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will fire a 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Season retrieved successfully for show",
+                        "schema": {
+                            "$ref": "#/definitions/episode_item"
+                        }
+                    }
+                },
+                "summary": "Get season by show ID and season ID",
+                "description": "Get a specific season via its ID and show ID",
+                "operationId": "get_series_season_api",
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/seasons/{season_id}/releases/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Seasons ID",
+                    "name": "season_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully deleted all releases for season",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete all season releases by show ID and season ID",
+                "description": "Releases are any seen entries that match the seasons. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Season-ID' header will be appended to the result headers.\nDelete all releases for a specific season of a specific show.",
+                "operationId": "delete_series_seasons_releases_api",
+                "parameters": [
+                    {
+                        "name": "downloaded",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter between release status"
+                    },
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will for 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Releases retrieved successfully for season",
+                        "schema": {
+                            "$ref": "#/definitions/release_list_schema"
+                        }
+                    }
+                },
+                "summary": "Get all season releases by show ID and season ID",
+                "description": "Releases are any seen entries that match the seasons. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Season-ID' header will be appended to the result headers.\nGet all matching releases for a specific season of a specific show.",
+                "operationId": "get_series_seasons_releases_api",
+                "parameters": [
+                    {
+                        "name": "downloaded",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Filter between release status"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Page number",
+                        "default": 1
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Results per page",
+                        "default": 50
+                    },
+                    {
+                        "name": "order",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sorting order",
+                        "default": "desc",
+                        "enum": [
+                            "desc",
+                            "asc"
+                        ]
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Sort by attribute",
+                        "default": "first_seen",
+                        "enum": [
+                            "first_seen",
+                            "downloaded",
+                            "proper_count",
+                            "title"
+                        ]
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully reset all downloaded releases for season",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Mark all downloaded season releases as not downloaded",
+                "description": "Releases are any seen entries that match the seasons. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Season-ID' header will be appended to the result headers.\nResets all of the downloaded releases of an season, clearing the quality to be downloaded again,",
+                "operationId": "put_series_seasons_releases_api",
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/series/{show_id}/seasons/{season_id}/releases/{rel_id}/": {
+            "parameters": [
+                {
+                    "description": "ID of the show",
+                    "name": "show_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Season ID",
+                    "name": "season_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "description": "Release ID",
+                    "name": "rel_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Release successfully deleted",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete episode release by show ID, season ID and release ID",
+                "description": "Releases are any seen entries that match the season. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Season-ID' header will be appended to the result headers.\nDelete a specific releases for a specific season of a specific show.",
+                "operationId": "delete_series_season_release_api",
+                "parameters": [
+                    {
+                        "name": "forget",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Enabling this will fire a 'forget' event that will delete the downloaded releases from the entire DB, enabling to re-download them",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "series"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Release retrieved successfully for season",
+                        "schema": {
+                            "$ref": "#/definitions/release_schema"
+                        }
+                    }
+                },
+                "summary": "Get season release by show ID, season ID and release ID",
+                "description": "Releases are any seen entries that match the season. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Season-ID' header will be appended to the result headers.\nGet a specific downloaded release for a specific season of a specific show",
+                "operationId": "get_series_season_release_api",
+                "tags": [
+                    "series"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully reset downloaded release status",
+                        "schema": {
+                            "$ref": "#/definitions/release_schema"
+                        }
+                    }
+                },
+                "summary": "Reset a downloaded release status",
+                "description": "Releases are any seen entries that match the season. \nThe 'Series-ID' header will be appended to the result headers.\nThe 'Season-ID' header will be appended to the result headers.\nResets the downloaded release status, clearing the quality to be downloaded again",
+                "operationId": "put_series_season_release_api",
+                "tags": [
+                    "series"
+                ]
+            }
+        },
+        "/server/config/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Flexget config",
+                        "schema": {
+                            "$ref": "#/definitions/empty"
+                        }
+                    }
+                },
+                "summary": "Get Flexget Config in JSON form",
+                "operationId": "get_server_config_api",
+                "tags": [
+                    "server"
+                ]
+            }
+        },
+        "/server/crash_logs/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved crash logs",
+                        "schema": {
+                            "$ref": "#/definitions/server.crash_logs"
+                        }
+                    }
+                },
+                "summary": "Get Crash logs",
+                "operationId": "get_server_crash_log_api",
+                "tags": [
+                    "server"
+                ]
+            }
+        },
+        "/server/log/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Streams as line delimited JSON"
+                    }
+                },
+                "summary": "Stream Flexget log Streams as line delimited JSON",
+                "operationId": "get_server_log_api",
+                "parameters": [
+                    {
+                        "name": "lines",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "How many lines to find before streaming",
+                        "default": 200
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Search filter support google like syntax"
+                    }
+                ],
+                "tags": [
+                    "server"
+                ]
+            }
+        },
+        "/server/manage/": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "502": {
+                        "description": "Config validation error",
+                        "schema": {
+                            "$ref": "#/definitions/config_validation_schema"
+                        }
+                    },
+                    "501": {
+                        "description": "YAML syntax error",
+                        "schema": {
+                            "$ref": "#/definitions/yaml_error_schema"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Manage server operations",
+                "operationId": "post_server_reload_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/server.manage"
+                        }
+                    }
+                ],
+                "tags": [
+                    "server"
+                ]
+            }
+        },
+        "/server/pid/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Reloaded config",
+                        "schema": {
+                            "$ref": "#/definitions/server.pid"
+                        }
+                    }
+                },
+                "summary": "Get server PID",
+                "operationId": "get_server_pidapi",
+                "tags": [
+                    "server"
+                ]
+            }
+        },
+        "/server/raw_config/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Flexget raw YAML config file encoded in Base64",
+                        "schema": {
+                            "$ref": "#/definitions/raw_config"
+                        }
+                    }
+                },
+                "summary": "Get raw YAML config file",
+                "description": "Return config file encoded in Base64",
+                "operationId": "get_server_raw_config_api",
+                "tags": [
+                    "server"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully updated config",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Update config",
+                "description": "Config file must be base64 encoded. A backup will be created, and if successful config will be loaded and saved to original file.",
+                "operationId": "post_server_raw_config_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/raw_config"
+                        }
+                    }
+                ],
+                "tags": [
+                    "server"
+                ]
+            }
+        },
+        "/server/version/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Flexget version",
+                        "schema": {
+                            "$ref": "#/definitions/server.version"
+                        }
+                    }
+                },
+                "summary": "Flexget Version",
+                "description": "In case of a request error when fetching latest flexget version, that value will return as null",
+                "operationId": "get_server_version_api",
+                "tags": [
+                    "server"
+                ]
+            }
+        },
+        "/status/": {
+            "parameters": [
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "last_execution_time",
+                    "enum": [
+                        "last_execution_time",
+                        "name",
+                        "id"
+                    ]
+                },
+                {
+                    "name": "include_execution",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Include the last execution of the task",
+                    "default": true
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.tasks_status_list"
+                        }
+                    }
+                },
+                "summary": "Get status tasks",
+                "operationId": "get_tasks_status_api",
+                "tags": [
+                    "status"
+                ]
+            }
+        },
+        "/status/{task_id}/": {
+            "parameters": [
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "last_execution_time",
+                    "enum": [
+                        "last_execution_time",
+                        "name",
+                        "id"
+                    ]
+                },
+                {
+                    "name": "include_execution",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Include the last execution of the task",
+                    "default": true
+                },
+                {
+                    "description": "ID of the status task",
+                    "name": "task_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.tasks_status"
+                        }
+                    }
+                },
+                "summary": "Get status task by ID",
+                "operationId": "get_task_status_api",
+                "tags": [
+                    "status"
+                ]
+            }
+        },
+        "/status/{task_id}/executions/": {
+            "parameters": [
+                {
+                    "name": "succeeded",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Filter by success status",
+                    "default": true
+                },
+                {
+                    "name": "produced",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Filter by tasks that produced entries",
+                    "default": true
+                },
+                {
+                    "name": "start_date",
+                    "in": "query",
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Filter by minimal start date. Example: '2012-01-01'. Default is 1 week ago.",
+                    "default": "2026-04-26"
+                },
+                {
+                    "name": "end_date",
+                    "in": "query",
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Filter by maximal end date. Example: '2012-01-01'"
+                },
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "start",
+                    "enum": [
+                        "start",
+                        "end",
+                        "succeeded",
+                        "produced",
+                        "accepted",
+                        "rejected",
+                        "failed",
+                        "abort_reason"
+                    ]
+                },
+                {
+                    "description": "ID of the status task",
+                    "name": "task_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.tasks_executions_list"
+                        }
+                    }
+                },
+                "summary": "Get task executions by ID",
+                "operationId": "get_task_status_executions_api",
+                "tags": [
+                    "status"
+                ]
+            }
+        },
+        "/tasks/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.list"
+                        }
+                    }
+                },
+                "summary": "List all tasks",
+                "description": "Task config schema too large to display, you can view the schema using the schema API",
+                "operationId": "get_tasks_api",
+                "parameters": [
+                    {
+                        "name": "include_config",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include task config",
+                        "default": true
+                    }
+                ],
+                "tags": [
+                    "tasks"
+                ]
+            },
+            "post": {
+                "responses": {
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "201": {
+                        "description": "Newly created task",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.task"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Add new task",
+                "description": "Task config schema too large to display, you can view the schema using the schema API",
+                "operationId": "post_tasks_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.task"
+                        },
+                        "description": "New task object"
+                    }
+                ],
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tasks/execute/": {
+            "post": {
+                "responses": {
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/task.execution"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Execute task and stream results",
+                "description": "For details on available parameters query /params/ endpoint",
+                "operationId": "post_task_execution_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/task_execution_input"
+                        }
+                    }
+                ],
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tasks/execute/params/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.execution_params"
+                        }
+                    }
+                },
+                "summary": "Execute payload parameters",
+                "description": "Available payload parameters for task execute",
+                "operationId": "get_task_execution_params",
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tasks/queue/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/task.queue"
+                        }
+                    }
+                },
+                "summary": "List task(s) in queue for execution",
+                "operationId": "get_task_queue_api",
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tasks/status/": {
+            "parameters": [
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "last_execution_time",
+                    "enum": [
+                        "last_execution_time",
+                        "name",
+                        "id"
+                    ]
+                },
+                {
+                    "name": "include_execution",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Include the last execution of the task",
+                    "default": true
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.tasks_status_list"
+                        }
+                    }
+                },
+                "summary": "Get status tasks",
+                "operationId": "get_tasks_status_api",
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tasks/status/{task_id}/": {
+            "parameters": [
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "last_execution_time",
+                    "enum": [
+                        "last_execution_time",
+                        "name",
+                        "id"
+                    ]
+                },
+                {
+                    "name": "include_execution",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Include the last execution of the task",
+                    "default": true
+                },
+                {
+                    "description": "ID of the status task",
+                    "name": "task_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.tasks_status"
+                        }
+                    }
+                },
+                "summary": "Get status task by ID",
+                "operationId": "get_task_status_api",
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tasks/status/{task_id}/executions/": {
+            "parameters": [
+                {
+                    "name": "succeeded",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Filter by success status",
+                    "default": true
+                },
+                {
+                    "name": "produced",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Filter by tasks that produced entries",
+                    "default": true
+                },
+                {
+                    "name": "start_date",
+                    "in": "query",
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Filter by minimal start date. Example: '2012-01-01'. Default is 1 week ago.",
+                    "default": "2026-04-26"
+                },
+                {
+                    "name": "end_date",
+                    "in": "query",
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Filter by maximal end date. Example: '2012-01-01'"
+                },
+                {
+                    "name": "page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                },
+                {
+                    "name": "per_page",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Results per page",
+                    "default": 50
+                },
+                {
+                    "name": "order",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sorting order",
+                    "default": "desc",
+                    "enum": [
+                        "desc",
+                        "asc"
+                    ]
+                },
+                {
+                    "name": "sort_by",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Sort by attribute",
+                    "default": "start",
+                    "enum": [
+                        "start",
+                        "end",
+                        "succeeded",
+                        "produced",
+                        "accepted",
+                        "rejected",
+                        "failed",
+                        "abort_reason"
+                    ]
+                },
+                {
+                    "description": "ID of the status task",
+                    "name": "task_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.tasks_executions_list"
+                        }
+                    }
+                },
+                "summary": "Get task executions by ID",
+                "operationId": "get_task_status_executions_api",
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tasks/{task}/": {
+            "parameters": [
+                {
+                    "description": "task name",
+                    "name": "task",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "deleted task",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    }
+                },
+                "summary": "Delete a task",
+                "description": "Task config schema too large to display, you can view the schema using the schema API",
+                "operationId": "delete_task_api",
+                "tags": [
+                    "tasks"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.task"
+                        }
+                    }
+                },
+                "summary": "Get task config",
+                "description": "Task config schema too large to display, you can view the schema using the schema API",
+                "operationId": "get_task_api",
+                "tags": [
+                    "tasks"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.task"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Update tasks config",
+                "description": "Task config schema too large to display, you can view the schema using the schema API",
+                "operationId": "put_task_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/tasks.task"
+                        }
+                    }
+                ],
+                "tags": [
+                    "tasks"
+                ]
+            }
+        },
+        "/tmdb/movies/": {
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/tmdb_search_schema"
+                        }
+                    }
+                },
+                "summary": "Get TMDB movie data",
+                "description": "Either title, TMDB ID or IMDB ID are required for a lookup",
+                "operationId": "get_tmdb_movies_api",
+                "parameters": [
+                    {
+                        "name": "title",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Movie title"
+                    },
+                    {
+                        "name": "tmdb_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "TMDB ID"
+                    },
+                    {
+                        "name": "imdb_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "IMDB ID"
+                    },
+                    {
+                        "name": "language",
+                        "in": "query",
+                        "type": "string",
+                        "description": "ISO 639-1 language code"
+                    },
+                    {
+                        "name": "year",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Movie year"
+                    },
+                    {
+                        "name": "only_cached",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Return only cached results"
+                    },
+                    {
+                        "name": "include_posters",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include posters in response",
+                        "default": false
+                    },
+                    {
+                        "name": "include_backdrops",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include backdrops in response",
+                        "default": false
+                    }
+                ],
+                "tags": [
+                    "tmdb"
+                ]
+            }
+        },
+        "/trakt/movies/": {
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully found show",
+                        "schema": {
+                            "$ref": "#/definitions/movie_return_schema"
+                        }
+                    }
+                },
+                "summary": "Trakt movie lookup",
+                "operationId": "get_trakt_movie_search_api",
+                "parameters": [
+                    {
+                        "name": "title",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Movie Name"
+                    },
+                    {
+                        "name": "year",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Lookup year"
+                    },
+                    {
+                        "name": "trakt_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Trakt ID"
+                    },
+                    {
+                        "name": "trakt_slug",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Trakt slug"
+                    },
+                    {
+                        "name": "tmdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TMDB ID"
+                    },
+                    {
+                        "name": "imdb_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "IMDB ID"
+                    },
+                    {
+                        "name": "tvdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVDB ID"
+                    },
+                    {
+                        "name": "tvrage_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVRage ID"
+                    },
+                    {
+                        "name": "include_actors",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include actors in response"
+                    },
+                    {
+                        "name": "include_translations",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include translations in response"
+                    }
+                ],
+                "tags": [
+                    "trakt"
+                ]
+            }
+        },
+        "/trakt/movies/{title}": {
+            "parameters": [
+                {
+                    "description": "Movie name",
+                    "name": "title",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "301": {
+                        "description": "Success"
+                    }
+                },
+                "operationId": "get_trakt_movie_with_title_search_api",
+                "parameters": [
+                    {
+                        "description": "Movie Name",
+                        "name": "title",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "year",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Lookup year"
+                    },
+                    {
+                        "name": "trakt_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Trakt ID"
+                    },
+                    {
+                        "name": "trakt_slug",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Trakt slug"
+                    },
+                    {
+                        "name": "tmdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TMDB ID"
+                    },
+                    {
+                        "name": "imdb_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "IMDB ID"
+                    },
+                    {
+                        "name": "tvdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVDB ID"
+                    },
+                    {
+                        "name": "tvrage_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVRage ID"
+                    },
+                    {
+                        "name": "include_actors",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include actors in response"
+                    },
+                    {
+                        "name": "include_translations",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include translations in response"
+                    }
+                ],
+                "tags": [
+                    "trakt"
+                ]
+            }
+        },
+        "/trakt/series/": {
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully found show",
+                        "schema": {
+                            "$ref": "#/definitions/series_return_schema"
+                        }
+                    }
+                },
+                "summary": "Trakt series lookup",
+                "operationId": "get_trakt_series_search_api",
+                "parameters": [
+                    {
+                        "name": "title",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Movie Name"
+                    },
+                    {
+                        "name": "year",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Lookup year"
+                    },
+                    {
+                        "name": "trakt_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Trakt ID"
+                    },
+                    {
+                        "name": "trakt_slug",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Trakt slug"
+                    },
+                    {
+                        "name": "tmdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TMDB ID"
+                    },
+                    {
+                        "name": "imdb_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "IMDB ID"
+                    },
+                    {
+                        "name": "tvdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVDB ID"
+                    },
+                    {
+                        "name": "tvrage_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVRage ID"
+                    },
+                    {
+                        "name": "include_actors",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include actors in response"
+                    },
+                    {
+                        "name": "include_translations",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include translations in response"
+                    }
+                ],
+                "tags": [
+                    "trakt"
+                ]
+            }
+        },
+        "/trakt/series/{title}": {
+            "parameters": [
+                {
+                    "description": "Series name",
+                    "name": "title",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "301": {
+                        "description": "Success"
+                    }
+                },
+                "operationId": "get_trakt_series_with_title_search_api",
+                "parameters": [
+                    {
+                        "description": "Movie Name",
+                        "name": "title",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "year",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Lookup year"
+                    },
+                    {
+                        "name": "trakt_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "Trakt ID"
+                    },
+                    {
+                        "name": "trakt_slug",
+                        "in": "query",
+                        "type": "string",
+                        "description": "Trakt slug"
+                    },
+                    {
+                        "name": "tmdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TMDB ID"
+                    },
+                    {
+                        "name": "imdb_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "IMDB ID"
+                    },
+                    {
+                        "name": "tvdb_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVDB ID"
+                    },
+                    {
+                        "name": "tvrage_id",
+                        "in": "query",
+                        "type": "integer",
+                        "description": "TVRage ID"
+                    },
+                    {
+                        "name": "include_actors",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include actors in response"
+                    },
+                    {
+                        "name": "include_translations",
+                        "in": "query",
+                        "type": "boolean",
+                        "description": "Include translations in response"
+                    }
+                ],
+                "tags": [
+                    "trakt"
+                ]
+            }
+        },
+        "/tvdb/episode/{tvdb_id}/": {
+            "parameters": [
+                {
+                    "name": "language",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Language abbreviation string for different language support",
+                    "default": "en"
+                },
+                {
+                    "name": "season_number",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Season number"
+                },
+                {
+                    "name": "ep_number",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Episode number"
+                },
+                {
+                    "name": "absolute_number",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Absolute episode number"
+                },
+                {
+                    "name": "air_date",
+                    "in": "query",
+                    "type": "string",
+                    "format": "date",
+                    "description": "Episode airdate in `YYYY-mm-dd` format"
+                },
+                {
+                    "description": "TVDB ID of show",
+                    "name": "tvdb_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully found episode",
+                        "schema": {
+                            "$ref": "#/definitions/tvdb_episode_schema"
+                        }
+                    }
+                },
+                "summary": "TheTVDB episode lookup",
+                "operationId": "get_tvdb_episode_search_api",
+                "tags": [
+                    "tvdb"
+                ]
+            }
+        },
+        "/tvdb/search/": {
+            "parameters": [
+                {
+                    "name": "language",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Language abbreviation string for different language support",
+                    "default": "en"
+                },
+                {
+                    "name": "search_name",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Series Name"
+                },
+                {
+                    "name": "imdb_id",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Series IMDB ID"
+                },
+                {
+                    "name": "zap2it_id",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Series ZAP2IT ID"
+                },
+                {
+                    "name": "force_search",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Force online lookup or allow for result to be retrieved from cache"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully got results",
+                        "schema": {
+                            "$ref": "#/definitions/tvdb_search_results_schema"
+                        }
+                    }
+                },
+                "summary": "TheTVDB series search",
+                "operationId": "get_tvdb_series_search_api",
+                "tags": [
+                    "tvdb"
+                ]
+            }
+        },
+        "/tvdb/series/{title}/": {
+            "parameters": [
+                {
+                    "name": "language",
+                    "in": "query",
+                    "type": "string",
+                    "description": "Language abbreviation string for different language support",
+                    "default": "en"
+                },
+                {
+                    "name": "include_actors",
+                    "in": "query",
+                    "type": "boolean",
+                    "description": "Include actors in response"
+                },
+                {
+                    "description": "TV Show name or TVDB ID",
+                    "name": "title",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully found show",
+                        "schema": {
+                            "$ref": "#/definitions/tvdb_series_schema"
+                        }
+                    }
+                },
+                "summary": "TheTVDB series lookup",
+                "operationId": "get_tvdb_series_lookup_api",
+                "tags": [
+                    "tvdb"
+                ]
+            }
+        },
+        "/tvmaze/episode/{tvmaze_id}/": {
+            "parameters": [
+                {
+                    "name": "season_num",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Season number"
+                },
+                {
+                    "name": "ep_num",
+                    "in": "query",
+                    "type": "integer",
+                    "description": "Episode number"
+                },
+                {
+                    "name": "air_date",
+                    "in": "query",
+                    "type": "string",
+                    "format": "date",
+                    "description": "Air date in the format of '2012-01-01'"
+                },
+                {
+                    "description": "TVMaze ID of show",
+                    "name": "tvmaze_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully found episode",
+                        "schema": {
+                            "$ref": "#/definitions/tvmaze_episode_schema"
+                        }
+                    }
+                },
+                "summary": "TVMaze episode lookup",
+                "operationId": "get_tvdb_episode_search_api",
+                "tags": [
+                    "tvmaze"
+                ]
+            }
+        },
+        "/tvmaze/series/{title}/": {
+            "parameters": [
+                {
+                    "description": "TV Show name or TVMaze ID",
+                    "name": "title",
+                    "in": "path",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully found show",
+                        "schema": {
+                            "$ref": "#/definitions/tvmaze_series_schema"
+                        }
+                    }
+                },
+                "summary": "TVMaze series lookup",
+                "operationId": "get_tvdb_series_search_api",
+                "tags": [
+                    "tvmaze"
+                ]
+            }
+        },
+        "/user/": {
+            "put": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/base_message"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    }
+                },
+                "summary": "Change user password",
+                "description": "Change user password. A score of at least 3 is needed.See https://github.com/dropbox/zxcvbn for details",
+                "operationId": "put_user_management_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/user_password_input"
+                        },
+                        "description": "Password change schema"
+                    }
+                ],
+                "tags": [
+                    "user"
+                ]
+            }
+        },
+        "/user/token/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Successfully got user token",
+                        "schema": {
+                            "$ref": "#/definitions/user_token_response"
+                        }
+                    }
+                },
+                "description": "Get current user token",
+                "operationId": "get_user_management_token_api",
+                "tags": [
+                    "user"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "200": {
+                        "description": "Successfully changed user token",
+                        "schema": {
+                            "$ref": "#/definitions/user_token_response"
+                        }
+                    }
+                },
+                "summary": "Change current user token",
+                "description": "Get new user token",
+                "operationId": "put_user_management_token_api",
+                "tags": [
+                    "user"
+                ]
+            }
+        },
+        "/variables/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/empty"
+                        }
+                    }
+                },
+                "summary": "Get variables data from DB",
+                "operationId": "get_variables_api",
+                "tags": [
+                    "variables"
+                ]
+            },
+            "put": {
+                "responses": {
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "201": {
+                        "description": "Successfully updated variables file"
+                    }
+                },
+                "summary": "Store variables data to DB",
+                "description": "Note that editing variables may not be persistent, depending on user config",
+                "operationId": "put_variables_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/empty"
+                        }
+                    }
+                ],
+                "tags": [
+                    "variables"
+                ]
+            },
+            "patch": {
+                "responses": {
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/validation_error"
+                        }
+                    },
+                    "200": {
+                        "description": "Successfully updated variables file"
+                    }
+                },
+                "summary": "Update variables data to DB",
+                "description": "Note that editing variables may not be persistent, depending on user config",
+                "operationId": "patch_variables_api",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/empty"
+                        }
+                    }
+                ],
+                "tags": [
+                    "variables"
+                ]
+            }
+        }
+    },
+    "info": {
+        "title": "Flexget API v1.8.0",
+        "version": "1.8.0",
+        "description": "View and manage flexget core operations and plugins. Open each endpoint view for usage information. Navigate to http://flexget.com/API for more details."
+    },
+    "produces": [
+        "application/json"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "tags": [
+        {
+            "name": "auth",
+            "description": "Authentication"
+        },
+        {
+            "name": "cached",
+            "description": "Cache remote resources"
+        },
+        {
+            "name": "database",
+            "description": "Manage Flexget DB"
+        },
+        {
+            "name": "plugins",
+            "description": "Get Flexget plugins"
+        },
+        {
+            "name": "schema",
+            "description": "Config and plugin schemas"
+        },
+        {
+            "name": "server",
+            "description": "Manage Daemon"
+        },
+        {
+            "name": "tasks",
+            "description": "Manage Tasks"
+        },
+        {
+            "name": "inject",
+            "description": "Entry injection API"
+        },
+        {
+            "name": "user",
+            "description": "Manage user login credentials"
+        },
+        {
+            "name": "variables",
+            "description": "View and edit config variables"
+        },
+        {
+            "name": "pending",
+            "description": "View and manage pending entries"
+        },
+        {
+            "name": "tvdb",
+            "description": "TheTVDB Shows"
+        },
+        {
+            "name": "tvmaze",
+            "description": "TVMaze Shows"
+        },
+        {
+            "name": "series",
+            "description": "FlexGet Series operations"
+        },
+        {
+            "name": "history",
+            "description": "Entry History"
+        },
+        {
+            "name": "failed",
+            "description": "View and manage failed entries"
+        },
+        {
+            "name": "rejected",
+            "description": "View and manage remembered rejected entries"
+        },
+        {
+            "name": "schedules",
+            "description": "Task Scheduler"
+        },
+        {
+            "name": "status",
+            "description": "View and manage task execution status"
+        },
+        {
+            "name": "seen",
+            "description": "Managed Flexget seen entries and fields"
+        },
+        {
+            "name": "imdb",
+            "description": "IMDB lookup endpoint"
+        },
+        {
+            "name": "trakt",
+            "description": "Trakt lookup endpoint"
+        },
+        {
+            "name": "irc",
+            "description": "View and manage IRC connections"
+        },
+        {
+            "name": "tmdb",
+            "description": "TMDB lookup endpoint"
+        },
+        {
+            "name": "pending_list",
+            "description": "Pending List operations"
+        },
+        {
+            "name": "entry_list",
+            "description": "Entry List operations"
+        },
+        {
+            "name": "movie_list",
+            "description": "Movie List operations"
+        }
+    ],
+    "definitions": {
+        "auth.login": {
+            "type": "object",
+            "properties": {
+                "username": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "username",
+                "password"
+            ],
+            "additionalProperties": false
+        },
+        "base_message": {
+            "type": "object",
+            "properties": {
+                "status_code": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "status_code",
+                "message",
+                "status"
+            ]
+        },
+        "validation_error": {
+            "type": "object",
+            "properties": {
+                "validation_errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "message": {
+                                "type": "string",
+                                "description": "A human readable message explaining the error."
+                            },
+                            "validator": {
+                                "type": "string",
+                                "description": "The name of the failed validator."
+                            },
+                            "validator_value": {
+                                "type": "string",
+                                "description": "The value for the failed validator in the schema."
+                            },
+                            "path": {
+                                "type": "string"
+                            },
+                            "schema_path": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "validation_errors"
+            ]
+        },
+        "db_schema": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "cleanup",
+                        "vacuum",
+                        "plugin_reset"
+                    ]
+                },
+                "plugin_name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "operation"
+            ],
+            "additionalProperties": false
+        },
+        "plugins_list": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "plugin_list_reply": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "api_ver": {
+                        "type": "integer"
+                    },
+                    "builtin": {
+                        "type": "boolean"
+                    },
+                    "category": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "contexts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "debug": {
+                        "type": "boolean"
+                    },
+                    "interfaces": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "phase_handlers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "phase": {
+                                    "type": "string"
+                                },
+                                "priority": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "plugin_object": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "api_ver": {
+                    "type": "integer"
+                },
+                "builtin": {
+                    "type": "boolean"
+                },
+                "category": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "contexts": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "debug": {
+                    "type": "boolean"
+                },
+                "interfaces": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "phase_handlers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "phase": {
+                                "type": "string"
+                            },
+                            "priority": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "schema.list": {
+            "type": "object",
+            "properties": {
+                "schemas": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            }
+        },
+        "server.manage": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "reload",
+                        "shutdown"
+                    ]
+                },
+                "force": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "operation"
+            ],
+            "additionalProperties": false
+        },
+        "config_validation_schema": {
+            "type": "object",
+            "properties": {
+                "status_code": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "config_path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "status_code",
+                "message",
+                "status"
+            ]
+        },
+        "yaml_error_schema": {
+            "type": "object",
+            "properties": {
+                "status_code": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "column": {
+                    "type": "integer"
+                },
+                "line": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "status_code",
+                "message",
+                "status"
+            ]
+        },
+        "server.pid": {
+            "type": "object",
+            "properties": {
+                "pid": {
+                    "type": "integer"
+                }
+            }
+        },
+        "empty": {
+            "type": "object"
+        },
+        "raw_config": {
+            "type": "object",
+            "properties": {
+                "raw_config": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.version": {
+            "type": "object",
+            "properties": {
+                "flexget_version": {
+                    "type": "string"
+                },
+                "api_version": {
+                    "type": "string"
+                },
+                "latest_version": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "server.crash_logs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "tasks.task": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "name",
+                "config"
+            ],
+            "additionalProperties": false
+        },
+        "tasks.list": {
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/tasks.task"
+                    }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "task.queue": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "current_phase": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "current_plugin": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            }
+        },
+        "tasks.execution_params": {
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
+        },
+        "task_execution_input": {
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "progress": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include task progress updates"
+                },
+                "summary": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include task summary"
+                },
+                "entry_dump": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include dump of entries including fields"
+                },
+                "inject": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string",
+                                "description": "Title of the entry. If not supplied it will be attempted to retrieve it from URL headers"
+                            },
+                            "url": {
+                                "type": "string",
+                                "format": "url",
+                                "description": "URL of the entry"
+                            },
+                            "force": {
+                                "type": "boolean",
+                                "description": "Prevent any plugins from rejecting this entry"
+                            },
+                            "accept": {
+                                "type": "boolean",
+                                "description": "Accept this entry immediately upon injection (disregard task filters)"
+                            },
+                            "fields": {
+                                "type": "object",
+                                "description": "A array of objects that can contain any other value for the entry"
+                            }
+                        },
+                        "required": [
+                            "url"
+                        ]
+                    },
+                    "description": "A List of entry objects"
+                },
+                "loglevel": {
+                    "type": "string",
+                    "description": "Specify log level",
+                    "enum": [
+                        "critical",
+                        "error",
+                        "warning",
+                        "info",
+                        "verbose",
+                        "debug",
+                        "trace"
+                    ]
+                },
+                "learn": {
+                    "description": "Matches are not downloaded but will be skipped in the future",
+                    "type": "boolean"
+                },
+                "no_cache": {
+                    "description": "Disable caches. works only in plugins that have explicit support",
+                    "type": "boolean"
+                },
+                "tail_reset": {
+                    "description": "Reset tail position for a file",
+                    "type": "string"
+                },
+                "discover_now": {
+                    "description": "Immediately try to discover everything",
+                    "type": "boolean"
+                },
+                "cli_config": {
+                    "description": "Configuration parameters through commandline",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                "dl_path": {
+                    "description": "Override path for download plugin, applies to all executed tasks",
+                    "type": "string"
+                },
+                "template": {
+                    "description": "Execute tasks using given template",
+                    "type": "string"
+                },
+                "now": {
+                    "description": "Run task(s) even if the interval plugin would normally prevent it",
+                    "type": "boolean"
+                },
+                "stop_waiting": {
+                    "description": "Stop timeframe for a given series",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "tasks"
+            ],
+            "additionalProperties": false
+        },
+        "task.execution": {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "stream": {
+                            "type": "array",
+                            "items": {
+                                "progress": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "pending",
+                                                "running",
+                                                "complete"
+                                            ]
+                                        },
+                                        "phase": {
+                                            "type": "string",
+                                            "enum": [
+                                                "prepare",
+                                                "start",
+                                                "input",
+                                                "metainfo",
+                                                "filter",
+                                                "urlrewrite",
+                                                "download",
+                                                "modify",
+                                                "output",
+                                                "learn",
+                                                "exit"
+                                            ]
+                                        },
+                                        "plugin": {
+                                            "type": "string"
+                                        },
+                                        "percent": {
+                                            "type": "float"
+                                        }
+                                    }
+                                },
+                                "summary": {
+                                    "type": "object",
+                                    "properties": {
+                                        "accepted": {
+                                            "type": "integer"
+                                        },
+                                        "rejected": {
+                                            "type": "integer"
+                                        },
+                                        "failed": {
+                                            "type": "integer"
+                                        },
+                                        "undecided": {
+                                            "type": "integer"
+                                        },
+                                        "aborted": {
+                                            "type": "boolean"
+                                        },
+                                        "abort_reason": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "entry_dump": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                },
+                                "log": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "tasks.tasks_status_list": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "last_execution_time": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "last_execution": {
+                        "type": "object",
+                        "properties": {
+                            "abort_reason": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "accepted": {
+                                "type": "integer"
+                            },
+                            "end": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "failed": {
+                                "type": "integer"
+                            },
+                            "id": {
+                                "type": "integer"
+                            },
+                            "produced": {
+                                "type": "integer"
+                            },
+                            "rejected": {
+                                "type": "integer"
+                            },
+                            "start": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "succeeded": {
+                                "type": "boolean"
+                            },
+                            "task_id": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "tasks.tasks_status": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "last_execution_time": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "last_execution": {
+                    "type": "object",
+                    "properties": {
+                        "abort_reason": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "accepted": {
+                            "type": "integer"
+                        },
+                        "end": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "failed": {
+                            "type": "integer"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "produced": {
+                            "type": "integer"
+                        },
+                        "rejected": {
+                            "type": "integer"
+                        },
+                        "start": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "succeeded": {
+                            "type": "boolean"
+                        },
+                        "task_id": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "id",
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "tasks.tasks_executions_list": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "abort_reason": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "accepted": {
+                        "type": "integer"
+                    },
+                    "end": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "failed": {
+                        "type": "integer"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "produced": {
+                        "type": "integer"
+                    },
+                    "rejected": {
+                        "type": "integer"
+                    },
+                    "start": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "succeeded": {
+                        "type": "boolean"
+                    },
+                    "task_id": {
+                        "type": "integer"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "user_password_input": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "password"
+            ],
+            "additionalProperties": false
+        },
+        "user_token_response": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "pending.operation": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "approve",
+                        "reject"
+                    ]
+                }
+            },
+            "required": [
+                "operation"
+            ],
+            "additionalProperties": false
+        },
+        "pending.entry_list": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "task_name": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "approved": {
+                        "type": "boolean"
+                    },
+                    "added": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            }
+        },
+        "pending.entry": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "task_name": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "approved": {
+                    "type": "boolean"
+                },
+                "added": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "tvdb_series_schema": {
+            "type": "object",
+            "properties": {
+                "tvdb_id": {
+                    "type": "integer"
+                },
+                "last_updated": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "expired": {
+                    "type": "boolean"
+                },
+                "series_name": {
+                    "type": "string"
+                },
+                "rating": {
+                    "type": "number"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "type": "integer"
+                },
+                "airs_time": {
+                    "type": "string"
+                },
+                "airs_dayofweek": {
+                    "type": "string"
+                },
+                "content_rating": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": "string"
+                },
+                "overview": {
+                    "type": "string"
+                },
+                "imdb_id": {
+                    "type": "string"
+                },
+                "zap2it_id": {
+                    "type": "string"
+                },
+                "banner": {
+                    "type": "string"
+                },
+                "first_aired": {
+                    "type": "string"
+                },
+                "actors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "aliases": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "posters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "language": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "tvdb_id",
+                "last_updated",
+                "expired",
+                "series_name",
+                "rating",
+                "status",
+                "runtime",
+                "airs_time",
+                "airs_dayofweek",
+                "content_rating",
+                "network",
+                "overview",
+                "imdb_id",
+                "zap2it_id",
+                "banner",
+                "first_aired",
+                "aliases",
+                "posters",
+                "genres",
+                "language"
+            ],
+            "additionalProperties": false
+        },
+        "tvdb_episode_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "expired": {
+                    "type": "boolean"
+                },
+                "last_update": {
+                    "type": "integer"
+                },
+                "season_number": {
+                    "type": "integer"
+                },
+                "episode_number": {
+                    "type": "integer"
+                },
+                "absolute_number": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "episode_name": {
+                    "type": "string"
+                },
+                "overview": {
+                    "type": "string"
+                },
+                "director": {
+                    "type": "string"
+                },
+                "rating": {
+                    "type": "number"
+                },
+                "image": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "first_aired": {
+                    "type": "string"
+                },
+                "series_id": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "id",
+                "expired",
+                "last_update",
+                "season_number",
+                "episode_number",
+                "absolute_number",
+                "episode_name",
+                "overview",
+                "director",
+                "rating",
+                "image",
+                "first_aired",
+                "series_id"
+            ],
+            "additionalProperties": false
+        },
+        "tvdb_search_results_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "aliases": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "first_aired": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "banner": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "network": {
+                        "type": "string"
+                    },
+                    "series_name": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "overview": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "tvdb_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "aliases",
+                    "first_aired",
+                    "banner",
+                    "network",
+                    "series_name",
+                    "status",
+                    "overview",
+                    "tvdb_id"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "tvmaze_series_schema": {
+            "type": "object",
+            "properties": {
+                "tvmaze_id": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "rating": {
+                    "type": "number"
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "weight": {
+                    "type": "integer"
+                },
+                "updated": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "object",
+                    "properties": {
+                        "days": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "time": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "url": {
+                    "type": "string",
+                    "format": "url"
+                },
+                "original_image": {
+                    "type": "string"
+                },
+                "medium_image": {
+                    "type": "string"
+                },
+                "tvdb_id": {
+                    "type": "integer"
+                },
+                "tvrage_id": {
+                    "type": "integer"
+                },
+                "premiered": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "year": {
+                    "type": "integer"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "webchannel": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "runtime": {
+                    "type": "integer"
+                },
+                "show_type": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "last_update": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "required": [
+                "tvmaze_id",
+                "status",
+                "rating",
+                "genres",
+                "weight",
+                "updated",
+                "name",
+                "language",
+                "schedule",
+                "url",
+                "original_image",
+                "medium_image",
+                "tvdb_id",
+                "tvrage_id",
+                "premiered",
+                "year",
+                "summary",
+                "webchannel",
+                "runtime",
+                "show_type",
+                "network",
+                "last_update"
+            ],
+            "additionalProperties": false
+        },
+        "tvmaze_episode_schema": {
+            "type": "object",
+            "properties": {
+                "tvmaze_id": {
+                    "type": "integer"
+                },
+                "series_id": {
+                    "type": "integer"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "season_number": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "airdate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "original_image": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "medium_image": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "airstamp": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "runtime": {
+                    "type": "integer"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "last_update": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "required": [
+                "tvmaze_id",
+                "series_id",
+                "number",
+                "season_number",
+                "title",
+                "airdate",
+                "url",
+                "original_image",
+                "medium_image",
+                "airstamp",
+                "runtime",
+                "summary",
+                "last_update"
+            ],
+            "additionalProperties": false
+        },
+        "series_input_schema": {
+            "type": "object",
+            "properties": {
+                "begin_episode": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "format": "episode_or_season_id"
+                },
+                "alternate_names": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties:": false,
+            "required": [
+                "name"
+            ]
+        },
+        "list_series": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternate_names": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "in_tasks": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "lookup": {
+                        "type": "object",
+                        "properties": {
+                            "tvmaze": {
+                                "type": "object",
+                                "properties": {
+                                    "tvmaze_id": {
+                                        "type": "integer"
+                                    },
+                                    "status": {
+                                        "type": "string"
+                                    },
+                                    "rating": {
+                                        "type": "number"
+                                    },
+                                    "genres": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "weight": {
+                                        "type": "integer"
+                                    },
+                                    "updated": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "language": {
+                                        "type": "string"
+                                    },
+                                    "schedule": {
+                                        "type": "object",
+                                        "properties": {
+                                            "days": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "time": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "format": "url"
+                                    },
+                                    "original_image": {
+                                        "type": "string"
+                                    },
+                                    "medium_image": {
+                                        "type": "string"
+                                    },
+                                    "tvdb_id": {
+                                        "type": "integer"
+                                    },
+                                    "tvrage_id": {
+                                        "type": "integer"
+                                    },
+                                    "premiered": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "year": {
+                                        "type": "integer"
+                                    },
+                                    "summary": {
+                                        "type": "string"
+                                    },
+                                    "webchannel": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "runtime": {
+                                        "type": "integer"
+                                    },
+                                    "show_type": {
+                                        "type": "string"
+                                    },
+                                    "network": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "last_update": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    }
+                                },
+                                "required": [
+                                    "tvmaze_id",
+                                    "status",
+                                    "rating",
+                                    "genres",
+                                    "weight",
+                                    "updated",
+                                    "name",
+                                    "language",
+                                    "schedule",
+                                    "url",
+                                    "original_image",
+                                    "medium_image",
+                                    "tvdb_id",
+                                    "tvrage_id",
+                                    "premiered",
+                                    "year",
+                                    "summary",
+                                    "webchannel",
+                                    "runtime",
+                                    "show_type",
+                                    "network",
+                                    "last_update"
+                                ],
+                                "additionalProperties": false
+                            },
+                            "tvdb": {
+                                "type": "object",
+                                "properties": {
+                                    "tvdb_id": {
+                                        "type": "integer"
+                                    },
+                                    "last_updated": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "expired": {
+                                        "type": "boolean"
+                                    },
+                                    "series_name": {
+                                        "type": "string"
+                                    },
+                                    "rating": {
+                                        "type": "number"
+                                    },
+                                    "status": {
+                                        "type": "string"
+                                    },
+                                    "runtime": {
+                                        "type": "integer"
+                                    },
+                                    "airs_time": {
+                                        "type": "string"
+                                    },
+                                    "airs_dayofweek": {
+                                        "type": "string"
+                                    },
+                                    "content_rating": {
+                                        "type": "string"
+                                    },
+                                    "network": {
+                                        "type": "string"
+                                    },
+                                    "overview": {
+                                        "type": "string"
+                                    },
+                                    "imdb_id": {
+                                        "type": "string"
+                                    },
+                                    "zap2it_id": {
+                                        "type": "string"
+                                    },
+                                    "banner": {
+                                        "type": "string"
+                                    },
+                                    "first_aired": {
+                                        "type": "string"
+                                    },
+                                    "actors": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "aliases": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "posters": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "genres": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "language": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "tvdb_id",
+                                    "last_updated",
+                                    "expired",
+                                    "series_name",
+                                    "rating",
+                                    "status",
+                                    "runtime",
+                                    "airs_time",
+                                    "airs_dayofweek",
+                                    "content_rating",
+                                    "network",
+                                    "overview",
+                                    "imdb_id",
+                                    "zap2it_id",
+                                    "banner",
+                                    "first_aired",
+                                    "aliases",
+                                    "posters",
+                                    "genres",
+                                    "language"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "latest_episode": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "properties": {
+                            "first_seen": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time"
+                            },
+                            "id": {
+                                "type": "integer"
+                            },
+                            "identified_by": {
+                                "type": "string"
+                            },
+                            "identifier": {
+                                "type": "string"
+                            },
+                            "premiere": {
+                                "type": [
+                                    "string",
+                                    "boolean"
+                                ]
+                            },
+                            "number": {
+                                "type": "integer"
+                            },
+                            "season": {
+                                "type": "integer"
+                            },
+                            "series_id": {
+                                "type": "integer"
+                            },
+                            "number_of_releases": {
+                                "type": "integer"
+                            },
+                            "latest_release": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer"
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "downloaded": {
+                                        "type": "boolean"
+                                    },
+                                    "quality": {
+                                        "type": "string"
+                                    },
+                                    "proper_count": {
+                                        "type": "integer"
+                                    },
+                                    "first_seen": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "episode_id": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "id",
+                                    "title",
+                                    "downloaded",
+                                    "quality",
+                                    "proper_count",
+                                    "first_seen",
+                                    "episode_id"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "first_seen",
+                            "id",
+                            "identified_by",
+                            "identifier",
+                            "premiere",
+                            "number",
+                            "season",
+                            "series_id",
+                            "number_of_releases"
+                        ]
+                    },
+                    "begin_episode": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "properties": {
+                            "first_seen": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time"
+                            },
+                            "id": {
+                                "type": "integer"
+                            },
+                            "identified_by": {
+                                "type": "string"
+                            },
+                            "identifier": {
+                                "type": "string"
+                            },
+                            "premiere": {
+                                "type": [
+                                    "string",
+                                    "boolean"
+                                ]
+                            },
+                            "number": {
+                                "type": "integer"
+                            },
+                            "season": {
+                                "type": "integer"
+                            },
+                            "series_id": {
+                                "type": "integer"
+                            },
+                            "number_of_releases": {
+                                "type": "integer"
+                            },
+                            "latest_release": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer"
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "downloaded": {
+                                        "type": "boolean"
+                                    },
+                                    "quality": {
+                                        "type": "string"
+                                    },
+                                    "proper_count": {
+                                        "type": "integer"
+                                    },
+                                    "first_seen": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "episode_id": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "id",
+                                    "title",
+                                    "downloaded",
+                                    "quality",
+                                    "proper_count",
+                                    "first_seen",
+                                    "episode_id"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "first_seen",
+                            "id",
+                            "identified_by",
+                            "identifier",
+                            "premiere",
+                            "number",
+                            "season",
+                            "series_id",
+                            "number_of_releases"
+                        ]
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "alternate_names",
+                    "in_tasks"
+                ]
+            }
+        },
+        "show_details": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "alternate_names": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "in_tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "lookup": {
+                    "type": "object",
+                    "properties": {
+                        "tvmaze": {
+                            "type": "object",
+                            "properties": {
+                                "tvmaze_id": {
+                                    "type": "integer"
+                                },
+                                "status": {
+                                    "type": "string"
+                                },
+                                "rating": {
+                                    "type": "number"
+                                },
+                                "genres": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "weight": {
+                                    "type": "integer"
+                                },
+                                "updated": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "language": {
+                                    "type": "string"
+                                },
+                                "schedule": {
+                                    "type": "object",
+                                    "properties": {
+                                        "days": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "time": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "url": {
+                                    "type": "string",
+                                    "format": "url"
+                                },
+                                "original_image": {
+                                    "type": "string"
+                                },
+                                "medium_image": {
+                                    "type": "string"
+                                },
+                                "tvdb_id": {
+                                    "type": "integer"
+                                },
+                                "tvrage_id": {
+                                    "type": "integer"
+                                },
+                                "premiered": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                "year": {
+                                    "type": "integer"
+                                },
+                                "summary": {
+                                    "type": "string"
+                                },
+                                "webchannel": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "runtime": {
+                                    "type": "integer"
+                                },
+                                "show_type": {
+                                    "type": "string"
+                                },
+                                "network": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "last_update": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                }
+                            },
+                            "required": [
+                                "tvmaze_id",
+                                "status",
+                                "rating",
+                                "genres",
+                                "weight",
+                                "updated",
+                                "name",
+                                "language",
+                                "schedule",
+                                "url",
+                                "original_image",
+                                "medium_image",
+                                "tvdb_id",
+                                "tvrage_id",
+                                "premiered",
+                                "year",
+                                "summary",
+                                "webchannel",
+                                "runtime",
+                                "show_type",
+                                "network",
+                                "last_update"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "tvdb": {
+                            "type": "object",
+                            "properties": {
+                                "tvdb_id": {
+                                    "type": "integer"
+                                },
+                                "last_updated": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                "expired": {
+                                    "type": "boolean"
+                                },
+                                "series_name": {
+                                    "type": "string"
+                                },
+                                "rating": {
+                                    "type": "number"
+                                },
+                                "status": {
+                                    "type": "string"
+                                },
+                                "runtime": {
+                                    "type": "integer"
+                                },
+                                "airs_time": {
+                                    "type": "string"
+                                },
+                                "airs_dayofweek": {
+                                    "type": "string"
+                                },
+                                "content_rating": {
+                                    "type": "string"
+                                },
+                                "network": {
+                                    "type": "string"
+                                },
+                                "overview": {
+                                    "type": "string"
+                                },
+                                "imdb_id": {
+                                    "type": "string"
+                                },
+                                "zap2it_id": {
+                                    "type": "string"
+                                },
+                                "banner": {
+                                    "type": "string"
+                                },
+                                "first_aired": {
+                                    "type": "string"
+                                },
+                                "actors": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "aliases": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "posters": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "genres": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "language": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "tvdb_id",
+                                "last_updated",
+                                "expired",
+                                "series_name",
+                                "rating",
+                                "status",
+                                "runtime",
+                                "airs_time",
+                                "airs_dayofweek",
+                                "content_rating",
+                                "network",
+                                "overview",
+                                "imdb_id",
+                                "zap2it_id",
+                                "banner",
+                                "first_aired",
+                                "aliases",
+                                "posters",
+                                "genres",
+                                "language"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "latest_episode": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "first_seen": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "format": "date-time"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "identified_by": {
+                            "type": "string"
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "premiere": {
+                            "type": [
+                                "string",
+                                "boolean"
+                            ]
+                        },
+                        "number": {
+                            "type": "integer"
+                        },
+                        "season": {
+                            "type": "integer"
+                        },
+                        "series_id": {
+                            "type": "integer"
+                        },
+                        "number_of_releases": {
+                            "type": "integer"
+                        },
+                        "latest_release": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "title": {
+                                    "type": "string"
+                                },
+                                "downloaded": {
+                                    "type": "boolean"
+                                },
+                                "quality": {
+                                    "type": "string"
+                                },
+                                "proper_count": {
+                                    "type": "integer"
+                                },
+                                "first_seen": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                "episode_id": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "title",
+                                "downloaded",
+                                "quality",
+                                "proper_count",
+                                "first_seen",
+                                "episode_id"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "first_seen",
+                        "id",
+                        "identified_by",
+                        "identifier",
+                        "premiere",
+                        "number",
+                        "season",
+                        "series_id",
+                        "number_of_releases"
+                    ]
+                },
+                "begin_episode": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "first_seen": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "format": "date-time"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "identified_by": {
+                            "type": "string"
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "premiere": {
+                            "type": [
+                                "string",
+                                "boolean"
+                            ]
+                        },
+                        "number": {
+                            "type": "integer"
+                        },
+                        "season": {
+                            "type": "integer"
+                        },
+                        "series_id": {
+                            "type": "integer"
+                        },
+                        "number_of_releases": {
+                            "type": "integer"
+                        },
+                        "latest_release": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "title": {
+                                    "type": "string"
+                                },
+                                "downloaded": {
+                                    "type": "boolean"
+                                },
+                                "quality": {
+                                    "type": "string"
+                                },
+                                "proper_count": {
+                                    "type": "integer"
+                                },
+                                "first_seen": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                "episode_id": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "id",
+                                "title",
+                                "downloaded",
+                                "quality",
+                                "proper_count",
+                                "first_seen",
+                                "episode_id"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "first_seen",
+                        "id",
+                        "identified_by",
+                        "identifier",
+                        "premiere",
+                        "number",
+                        "season",
+                        "series_id",
+                        "number_of_releases"
+                    ]
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "alternate_names",
+                "in_tasks"
+            ]
+        },
+        "series_edit_schema": {
+            "type": "object",
+            "properties": {
+                "begin_episode": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "format": "episode_or_season_id"
+                },
+                "alternate_names": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "anyOf": [
+                {
+                    "required": [
+                        "begin_episode"
+                    ]
+                },
+                {
+                    "required": [
+                        "alternate_names"
+                    ]
+                }
+            ],
+            "additionalProperties:": false
+        },
+        "season_list": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "first_seen": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "identified_by": {
+                        "type": "string"
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "premiere": {
+                        "type": [
+                            "string",
+                            "boolean"
+                        ]
+                    },
+                    "season": {
+                        "type": "integer"
+                    },
+                    "series_id": {
+                        "type": "integer"
+                    },
+                    "number_of_releases": {
+                        "type": "integer"
+                    },
+                    "latest_release": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "title": {
+                                "type": "string"
+                            },
+                            "downloaded": {
+                                "type": "boolean"
+                            },
+                            "quality": {
+                                "type": "string"
+                            },
+                            "proper_count": {
+                                "type": "integer"
+                            },
+                            "first_seen": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "episode_id": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "title",
+                            "downloaded",
+                            "quality",
+                            "proper_count",
+                            "first_seen",
+                            "episode_id"
+                        ]
+                    }
+                },
+                "required": [
+                    "first_seen",
+                    "id",
+                    "identified_by",
+                    "identifier",
+                    "season",
+                    "series_id",
+                    "number_of_releases"
+                ]
+            }
+        },
+        "episode_item": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "first_seen": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "identified_by": {
+                    "type": "string"
+                },
+                "identifier": {
+                    "type": "string"
+                },
+                "premiere": {
+                    "type": [
+                        "string",
+                        "boolean"
+                    ]
+                },
+                "season": {
+                    "type": "integer"
+                },
+                "series_id": {
+                    "type": "integer"
+                },
+                "number_of_releases": {
+                    "type": "integer"
+                },
+                "latest_release": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "title": {
+                            "type": "string"
+                        },
+                        "downloaded": {
+                            "type": "boolean"
+                        },
+                        "quality": {
+                            "type": "string"
+                        },
+                        "proper_count": {
+                            "type": "integer"
+                        },
+                        "first_seen": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "episode_id": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "title",
+                        "downloaded",
+                        "quality",
+                        "proper_count",
+                        "first_seen",
+                        "episode_id"
+                    ]
+                }
+            },
+            "required": [
+                "first_seen",
+                "id",
+                "identified_by",
+                "identifier",
+                "season",
+                "series_id",
+                "number_of_releases"
+            ]
+        },
+        "episode_list": {
+            "type": "array",
+            "items": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "first_seen": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "identified_by": {
+                        "type": "string"
+                    },
+                    "identifier": {
+                        "type": "string"
+                    },
+                    "premiere": {
+                        "type": [
+                            "string",
+                            "boolean"
+                        ]
+                    },
+                    "number": {
+                        "type": "integer"
+                    },
+                    "season": {
+                        "type": "integer"
+                    },
+                    "series_id": {
+                        "type": "integer"
+                    },
+                    "number_of_releases": {
+                        "type": "integer"
+                    },
+                    "latest_release": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "title": {
+                                "type": "string"
+                            },
+                            "downloaded": {
+                                "type": "boolean"
+                            },
+                            "quality": {
+                                "type": "string"
+                            },
+                            "proper_count": {
+                                "type": "integer"
+                            },
+                            "first_seen": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "episode_id": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "title",
+                            "downloaded",
+                            "quality",
+                            "proper_count",
+                            "first_seen",
+                            "episode_id"
+                        ]
+                    }
+                },
+                "required": [
+                    "first_seen",
+                    "id",
+                    "identified_by",
+                    "identifier",
+                    "premiere",
+                    "number",
+                    "season",
+                    "series_id",
+                    "number_of_releases"
+                ]
+            }
+        },
+        "release_list_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "downloaded": {
+                        "type": "boolean"
+                    },
+                    "quality": {
+                        "type": "string"
+                    },
+                    "proper_count": {
+                        "type": "integer"
+                    },
+                    "first_seen": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "season_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "id",
+                    "title",
+                    "downloaded",
+                    "quality",
+                    "proper_count",
+                    "first_seen",
+                    "season_id"
+                ]
+            }
+        },
+        "release_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "downloaded": {
+                    "type": "boolean"
+                },
+                "quality": {
+                    "type": "string"
+                },
+                "proper_count": {
+                    "type": "integer"
+                },
+                "first_seen": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "season_id": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "id",
+                "title",
+                "downloaded",
+                "quality",
+                "proper_count",
+                "first_seen",
+                "season_id"
+            ]
+        },
+        "history.list": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "details": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "task": {
+                        "type": "string"
+                    },
+                    "time": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "details",
+                    "filename",
+                    "id",
+                    "task",
+                    "time",
+                    "title",
+                    "url"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "retry_entries_list_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "added_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "count": {
+                        "type": "integer"
+                    },
+                    "retry_time": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    }
+                },
+                "required": [
+                    "id",
+                    "title",
+                    "url",
+                    "added_at",
+                    "reason",
+                    "count",
+                    "retry_time"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "retry_failed_entry_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "added_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "count": {
+                    "type": "integer"
+                },
+                "retry_time": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                }
+            },
+            "required": [
+                "id",
+                "title",
+                "url",
+                "added_at",
+                "reason",
+                "count",
+                "retry_time"
+            ],
+            "additionalProperties": false
+        },
+        "rejected_entries_list_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "added": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "expires": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "rejected_by": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "title",
+                    "url",
+                    "added",
+                    "reason",
+                    "expires",
+                    "rejected_by"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "rejected_failed_entry_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "added": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "expires": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "rejected_by": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "title",
+                "url",
+                "added",
+                "reason",
+                "expires",
+                "rejected_by"
+            ],
+            "additionalProperties": false
+        },
+        "schedules.base": {
+            "type": "object",
+            "title": "schedule",
+            "description": "A schedule which runs specified tasks periodically",
+            "properties": {
+                "tasks": {
+                    "oneOf": [
+                        {
+                            "title": "multiple values",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "title": "single value"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": false
+                        },
+                        {
+                            "type": "string",
+                            "title": "single value"
+                        }
+                    ]
+                },
+                "interval": {
+                    "type": "object",
+                    "title": "Simple Interval",
+                    "properties": {
+                        "minutes": {
+                            "type": "number"
+                        },
+                        "hours": {
+                            "type": "number"
+                        },
+                        "days": {
+                            "type": "number"
+                        },
+                        "weeks": {
+                            "type": "number"
+                        },
+                        "jitter": {
+                            "type": "integer"
+                        }
+                    },
+                    "anyOf": [
+                        {
+                            "required": [
+                                "minutes"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "hours"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "days"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "weeks"
+                            ]
+                        }
+                    ],
+                    "error_anyOf": "Interval must be specified as one or more of minutes, hours, days, weeks",
+                    "additionalProperties": false
+                },
+                "schedule": {
+                    "type": "object",
+                    "title": "Advanced Cron Interval",
+                    "properties": {
+                        "year": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "month": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "day": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "week": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "day_of_week": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "hour": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "minute": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "jitter": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "tasks"
+            ],
+            "minProperties": 2,
+            "maxProperties": 2,
+            "error_minProperties": "Either `cron` or `interval` must be defined.",
+            "error_maxProperties": "Either `cron` or `interval` must be defined.",
+            "additionalProperties": false
+        },
+        "schedules.list": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "title": "schedule",
+                "description": "A schedule which runs specified tasks periodically",
+                "properties": {
+                    "tasks": {
+                        "oneOf": [
+                            {
+                                "title": "multiple values",
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "title": "single value"
+                                },
+                                "minItems": 1,
+                                "uniqueItems": false
+                            },
+                            {
+                                "type": "string",
+                                "title": "single value"
+                            }
+                        ]
+                    },
+                    "interval": {
+                        "type": "object",
+                        "title": "Simple Interval",
+                        "properties": {
+                            "minutes": {
+                                "type": "number"
+                            },
+                            "hours": {
+                                "type": "number"
+                            },
+                            "days": {
+                                "type": "number"
+                            },
+                            "weeks": {
+                                "type": "number"
+                            },
+                            "jitter": {
+                                "type": "integer"
+                            }
+                        },
+                        "anyOf": [
+                            {
+                                "required": [
+                                    "minutes"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "hours"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "days"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "weeks"
+                                ]
+                            }
+                        ],
+                        "error_anyOf": "Interval must be specified as one or more of minutes, hours, days, weeks",
+                        "additionalProperties": false
+                    },
+                    "schedule": {
+                        "type": "object",
+                        "title": "Advanced Cron Interval",
+                        "properties": {
+                            "year": {
+                                "type": [
+                                    "integer",
+                                    "string"
+                                ]
+                            },
+                            "month": {
+                                "type": [
+                                    "integer",
+                                    "string"
+                                ]
+                            },
+                            "day": {
+                                "type": [
+                                    "integer",
+                                    "string"
+                                ]
+                            },
+                            "week": {
+                                "type": [
+                                    "integer",
+                                    "string"
+                                ]
+                            },
+                            "day_of_week": {
+                                "type": [
+                                    "integer",
+                                    "string"
+                                ]
+                            },
+                            "hour": {
+                                "type": [
+                                    "integer",
+                                    "string"
+                                ]
+                            },
+                            "minute": {
+                                "type": [
+                                    "integer",
+                                    "string"
+                                ]
+                            },
+                            "jitter": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "tasks"
+                ],
+                "minProperties": 2,
+                "maxProperties": 3,
+                "error_minProperties": "Either `cron` or `interval` must be defined.",
+                "error_maxProperties": "Either `cron` or `interval` must be defined.",
+                "additionalProperties": false
+            }
+        },
+        "schedules.schedule": {
+            "type": "object",
+            "title": "schedule",
+            "description": "A schedule which runs specified tasks periodically",
+            "properties": {
+                "tasks": {
+                    "oneOf": [
+                        {
+                            "title": "multiple values",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "title": "single value"
+                            },
+                            "minItems": 1,
+                            "uniqueItems": false
+                        },
+                        {
+                            "type": "string",
+                            "title": "single value"
+                        }
+                    ]
+                },
+                "interval": {
+                    "type": "object",
+                    "title": "Simple Interval",
+                    "properties": {
+                        "minutes": {
+                            "type": "number"
+                        },
+                        "hours": {
+                            "type": "number"
+                        },
+                        "days": {
+                            "type": "number"
+                        },
+                        "weeks": {
+                            "type": "number"
+                        },
+                        "jitter": {
+                            "type": "integer"
+                        }
+                    },
+                    "anyOf": [
+                        {
+                            "required": [
+                                "minutes"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "hours"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "days"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "weeks"
+                            ]
+                        }
+                    ],
+                    "error_anyOf": "Interval must be specified as one or more of minutes, hours, days, weeks",
+                    "additionalProperties": false
+                },
+                "schedule": {
+                    "type": "object",
+                    "title": "Advanced Cron Interval",
+                    "properties": {
+                        "year": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "month": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "day": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "week": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "day_of_week": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "hour": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "minute": {
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
+                        },
+                        "jitter": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "id": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "tasks"
+            ],
+            "minProperties": 2,
+            "maxProperties": 3,
+            "error_minProperties": "Either `cron` or `interval` must be defined.",
+            "error_maxProperties": "Either `cron` or `interval` must be defined.",
+            "additionalProperties": false
+        },
+        "seen_search_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "task": {
+                        "type": "string"
+                    },
+                    "added": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "local": {
+                        "type": "boolean"
+                    },
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "field": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "added": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                "seen_entry_id": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "seen_object_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "task": {
+                    "type": "string"
+                },
+                "added": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "local": {
+                    "type": "boolean"
+                },
+                "fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "field": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "added": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "seen_entry_id": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "imdb_search_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "imdb_id": {
+                        "type": "string"
+                    },
+                    "match": {
+                        "type": "number"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "year": {
+                        "type": "number"
+                    },
+                    "thumbnail": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "imdb_id",
+                    "match",
+                    "name",
+                    "url",
+                    "year"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "series_return_schema": {
+            "type": "object",
+            "properties": {
+                "translations": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[/d]$": {
+                            "type": "object",
+                            "properties": {
+                                "overview": {
+                                    "type": "string"
+                                },
+                                "tagline": {
+                                    "type": "string"
+                                },
+                                "title": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "overview",
+                                "tagline",
+                                "title"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "actors": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[/d]$": {
+                            "type": "object",
+                            "properties": {
+                                "imdb_id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "tmdb_id": {
+                                    "type": "integer"
+                                },
+                                "trakt_id": {
+                                    "type": "integer"
+                                },
+                                "trakt_slug": {
+                                    "type": "string"
+                                },
+                                "birthday": {
+                                    "type": "string"
+                                },
+                                "biography": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "homepage": {
+                                    "type": "string"
+                                },
+                                "death": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "imdb_id",
+                                "name",
+                                "tmdb_id",
+                                "trakt_id",
+                                "trakt_slug",
+                                "birthday",
+                                "biography",
+                                "homepage",
+                                "death"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "cached_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "overview": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "runtime": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "rating": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "votes": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "language": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "homepage": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "slug": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "tmdb_id": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "imdb_id": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "tvdb_id": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "tvrage_id": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "first_aired": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "air_day": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "air_time": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "certification": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "network": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "country": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "status": {
+                    "type": "string"
+                },
+                "timezone": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "number_of_aired_episodes": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "cached_at",
+                "genres",
+                "id",
+                "overview",
+                "runtime",
+                "rating",
+                "votes",
+                "language",
+                "updated_at",
+                "title",
+                "year",
+                "homepage",
+                "slug",
+                "tmdb_id",
+                "imdb_id",
+                "tvdb_id",
+                "tvrage_id",
+                "first_aired",
+                "air_day",
+                "air_time",
+                "certification",
+                "network",
+                "country",
+                "status",
+                "timezone",
+                "number_of_aired_episodes"
+            ],
+            "additionalProperties": false
+        },
+        "movie_return_schema": {
+            "type": "object",
+            "properties": {
+                "translations": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[/d]$": {
+                            "type": "object",
+                            "properties": {
+                                "overview": {
+                                    "type": "string"
+                                },
+                                "tagline": {
+                                    "type": "string"
+                                },
+                                "title": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "overview",
+                                "tagline",
+                                "title"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "actors": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[/d]$": {
+                            "type": "object",
+                            "properties": {
+                                "imdb_id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "tmdb_id": {
+                                    "type": "integer"
+                                },
+                                "trakt_id": {
+                                    "type": "integer"
+                                },
+                                "trakt_slug": {
+                                    "type": "string"
+                                },
+                                "birthday": {
+                                    "type": "string"
+                                },
+                                "biography": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "homepage": {
+                                    "type": "string"
+                                },
+                                "death": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "imdb_id",
+                                "name",
+                                "tmdb_id",
+                                "trakt_id",
+                                "trakt_slug",
+                                "birthday",
+                                "biography",
+                                "homepage",
+                                "death"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "cached_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "overview": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "runtime": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "rating": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "votes": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "language": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "homepage": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "slug": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "tmdb_id": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "imdb_id": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "tagline": {
+                    "type": "string"
+                },
+                "released": {
+                    "type": "string"
+                },
+                "trailer": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "cached_at",
+                "genres",
+                "id",
+                "overview",
+                "runtime",
+                "rating",
+                "votes",
+                "language",
+                "updated_at",
+                "title",
+                "year",
+                "homepage",
+                "slug",
+                "tmdb_id",
+                "imdb_id",
+                "tagline",
+                "released",
+                "trailer"
+            ],
+            "additionalProperties": false
+        },
+        "irc.connections": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "patternProperties": {
+                    "\\w": {
+                        "type": "object",
+                        "properties": {
+                            "alive": {
+                                "type": "boolean"
+                            },
+                            "channels": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        "\\w": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            },
+                            "connected_channels": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "port": {
+                                "type": "integer"
+                            },
+                            "server": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "tmdb_search_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "imdb_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "original_name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "alternative_name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "year": {
+                    "type": "integer"
+                },
+                "runtime": {
+                    "type": "integer"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "overview": {
+                    "type": "string"
+                },
+                "tagline": {
+                    "type": "string"
+                },
+                "rating": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "votes": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "popularity": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "adult": {
+                    "type": "boolean"
+                },
+                "budget": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "revenue": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "homepage": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                },
+                "posters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            },
+                            "movie_id": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            },
+                            "urls": {
+                                "type": "object"
+                            },
+                            "file_path": {
+                                "type": "string"
+                            },
+                            "width": {
+                                "type": "integer"
+                            },
+                            "height": {
+                                "type": "integer"
+                            },
+                            "aspect_ratio": {
+                                "type": "number"
+                            },
+                            "vote_average": {
+                                "type": "number"
+                            },
+                            "vote_count": {
+                                "type": "integer"
+                            },
+                            "language_code": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "movie_id",
+                            "urls",
+                            "file_path",
+                            "width",
+                            "height",
+                            "aspect_ratio",
+                            "vote_average",
+                            "vote_count",
+                            "language_code"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                "backdrops": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            },
+                            "movie_id": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            },
+                            "urls": {
+                                "type": "object"
+                            },
+                            "file_path": {
+                                "type": "string"
+                            },
+                            "width": {
+                                "type": "integer"
+                            },
+                            "height": {
+                                "type": "integer"
+                            },
+                            "aspect_ratio": {
+                                "type": "number"
+                            },
+                            "vote_average": {
+                                "type": "number"
+                            },
+                            "vote_count": {
+                                "type": "integer"
+                            },
+                            "language_code": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "id",
+                            "movie_id",
+                            "urls",
+                            "file_path",
+                            "width",
+                            "height",
+                            "aspect_ratio",
+                            "vote_average",
+                            "vote_count",
+                            "language_code"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "lookup_language": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "id",
+                "name",
+                "year",
+                "original_name",
+                "alternative_name",
+                "runtime",
+                "language",
+                "overview",
+                "tagline",
+                "rating",
+                "votes",
+                "popularity",
+                "adult",
+                "budget",
+                "revenue",
+                "homepage",
+                "genres",
+                "updated"
+            ],
+            "additionalProperties": false
+        },
+        "pending_list.input_list": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "pending_list.return_lists": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "added_on": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "pending_list.return_list": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "added_on": {
+                    "type": "string"
+                }
+            }
+        },
+        "base_entry_schema": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "original_url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "title",
+                "original_url"
+            ],
+            "additionalProperties": true
+        },
+        "pending_list.entry_return_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "added_on": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "original_url": {
+                        "type": "string"
+                    },
+                    "approved": {
+                        "type": "boolean"
+                    },
+                    "entry": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "original_url": {
+                                "type": "string"
+                            },
+                            "approved": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "title",
+                            "original_url"
+                        ],
+                        "additionalProperties": true
+                    }
+                }
+            }
+        },
+        "pending_list.entry_base_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "added_on": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "original_url": {
+                    "type": "string"
+                },
+                "approved": {
+                    "type": "boolean"
+                },
+                "entry": {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string"
+                        },
+                        "original_url": {
+                            "type": "string"
+                        },
+                        "approved": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "title",
+                        "original_url"
+                    ],
+                    "additionalProperties": true
+                }
+            }
+        },
+        "pending_list.batch_remove_object": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "uniqueItems": true,
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "ids"
+            ],
+            "additionalProperties": false
+        },
+        "pending_list.batch_operation_object": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "approve",
+                        "reject"
+                    ]
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "uniqueItems": true,
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "operation",
+                "ids"
+            ],
+            "additionalProperties": false
+        },
+        "pending_list.operation_schema": {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "approve",
+                        "reject"
+                    ]
+                }
+            },
+            "required": [
+                "operation"
+            ],
+            "additionalProperties": false
+        },
+        "entry_list_input_object_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "entry_list_return_lists_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "added_on": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "entry_list_object_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "added_on": {
+                    "type": "string"
+                }
+            }
+        },
+        "entry_lists_entries_return_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "added_on": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "original_url": {
+                        "type": "string"
+                    },
+                    "entry": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "original_url": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "title",
+                            "original_url"
+                        ],
+                        "additionalProperties": true
+                    }
+                }
+            }
+        },
+        "entry_list_entry_base_schema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "added_on": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "original_url": {
+                    "type": "string"
+                },
+                "entry": {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string"
+                        },
+                        "original_url": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "title",
+                        "original_url"
+                    ],
+                    "additionalProperties": true
+                }
+            }
+        },
+        "entry_list.batch_remove_object": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "uniqueItems": true,
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "ids"
+            ],
+            "additionalProperties": false
+        },
+        "new_list": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "return_lists": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "added_on": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "list_object": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "added_on": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "input_movie_entry": {
+            "type": "object",
+            "properties": {
+                "movie_name": {
+                    "type": "string"
+                },
+                "movie_year": {
+                    "type": "integer"
+                },
+                "movie_identifiers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "additionalProperties": true
+                    }
+                }
+            },
+            "additionalProperties": true,
+            "required": [
+                "movie_name"
+            ]
+        },
+        "return_movies": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "added_on": {
+                        "type": "string"
+                    },
+                    "year": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
+                    "list_id": {
+                        "type": "integer"
+                    },
+                    "movie_list_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "minProperties": 1,
+                                "additionalProperties": true
+                            },
+                            "properties": {
+                                "id": {
+                                    "type": "integer"
+                                },
+                                "added_on": {
+                                    "type": "string"
+                                },
+                                "movie_id": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "movie_list_object": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "added_on": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "list_id": {
+                    "type": "integer"
+                },
+                "movie_list_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "minProperties": 1,
+                            "additionalProperties": true
+                        },
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "added_on": {
+                                "type": "string"
+                            },
+                            "movie_id": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "input_movie_list_id_object": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": true
+            }
+        },
+        "movie_list.identifiers": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "movie_list.batch_remove_object": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "uniqueItems": true,
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "ids"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "responses": {
+        "ParseError": {
+            "description": "When a mask can't be parsed"
+        },
+        "MaskError": {
+            "description": "When any error occurs on mask"
+        },
+        "PreconditionFailed": {},
+        "NotModified": {},
+        "Conflict": {},
+        "Unauthorized": {},
+        "BadRequest": {},
+        "ValidationError": {},
+        "NotFoundError": {},
+        "APIError": {}
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -201,7 +202,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -211,7 +212,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -245,7 +246,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -327,7 +328,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -354,6 +355,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -370,6 +372,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -386,6 +389,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -402,6 +406,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -418,6 +423,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -434,6 +440,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -450,6 +457,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -466,6 +474,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -482,6 +491,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,6 +508,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -514,6 +525,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -530,6 +542,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -546,6 +559,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -562,6 +576,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -578,6 +593,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,6 +610,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -610,6 +627,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -626,6 +644,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,6 +661,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,6 +678,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -674,6 +695,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -690,6 +712,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,6 +729,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -722,6 +746,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,6 +763,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -754,6 +780,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2823,6 +2850,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2833,6 +2861,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2843,9 +2872,17 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.0",
@@ -2892,6 +2929,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3104,6 +3142,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -3254,6 +3293,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3589,6 +3629,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4212,6 +4253,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4598,6 +4640,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -5180,6 +5223,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5257,7 +5301,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-3.0.0.tgz",
       "integrity": "sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "fast-uri": "^3.0.5",
@@ -5444,8 +5487,9 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -5963,6 +6007,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6133,6 +6178,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -6168,6 +6214,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -6182,7 +6240,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6203,6 +6260,12 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -6259,6 +6322,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6268,6 +6332,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6280,6 +6345,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
       "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6456,6 +6522,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -6929,6 +7001,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7058,6 +7131,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7094,6 +7168,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tree-kill": {
@@ -7182,6 +7271,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7220,6 +7310,15 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -7260,6 +7359,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -7325,6 +7434,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7902,6 +8012,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7915,6 +8026,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -8110,7 +8222,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8168,6 +8279,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -8189,6 +8301,7 @@
         "got": "^14.0.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
+        "tough-cookie": "^4.0.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -8196,6 +8309,7 @@
         "@tsconfig/node24": "^24.0.4",
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^25.6.0",
+        "@types/tough-cookie": "^4.0.0",
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.2.1",
         "prettier": "^3.8.3",
@@ -8348,6 +8462,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,7 @@
     "@tsconfig/node24": "^24.0.4",
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^25.6.0",
+    "@types/tough-cookie": "^4.0.0",
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.2.1",
     "prettier": "^3.8.3",
@@ -46,6 +47,7 @@
     "got": "^14.0.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
+    "tough-cookie": "^4.0.0",
     "zod": "^4.3.6"
   }
 }

--- a/packages/backend/prisma/migrations/20260504002425_add_flex_integration/migration.sql
+++ b/packages/backend/prisma/migrations/20260504002425_add_flex_integration/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "FlexgetIntegration" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "baseUrl" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FlexgetIntegration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ListIntegration" (
+    "id" SERIAL NOT NULL,
+    "listId" INTEGER NOT NULL,
+    "entryListName" TEXT NOT NULL,
+    "remoteListId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ListIntegration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FlexgetIntegration_userId_key" ON "FlexgetIntegration"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ListIntegration_listId_key" ON "ListIntegration"("listId");
+
+-- AddForeignKey
+ALTER TABLE "FlexgetIntegration" ADD CONSTRAINT "FlexgetIntegration_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ListIntegration" ADD CONSTRAINT "ListIntegration_listId_fkey" FOREIGN KEY ("listId") REFERENCES "List"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/migrations/20260504071238_add_remote_entry_id_to_listitem/migration.sql
+++ b/packages/backend/prisma/migrations/20260504071238_add_remote_entry_id_to_listitem/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ListItem" ADD COLUMN     "remoteEntryId" INTEGER;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -156,6 +156,7 @@ model ListItem {
   seriesTmdbId  String?
   seasonNumber  Int?
   episodeNumber Int?
+  remoteEntryId Int?
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
 }

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   tvReviews      TvReview[]
   tvComments     TvComment[]
   lists          List[]
+  flexgetIntegration FlexgetIntegration?
 }
 
 model Review {
@@ -135,14 +136,15 @@ model TvComment {
 }
 
 model List {
-  id          Int        @id @default(autoincrement())
-  title       String
-  description String?
-  creatorId   Int
-  creator     User       @relation(fields: [creatorId], references: [id], onDelete: Cascade)
-  items       ListItem[]
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @updatedAt
+  id                 Int             @id @default(autoincrement())
+  title              String
+  description        String?
+  creatorId          Int
+  creator            User            @relation(fields: [creatorId], references: [id], onDelete: Cascade)
+  items              ListItem[]
+  flexgetConnection  ListIntegration?
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
 }
 
 model ListItem {
@@ -156,6 +158,27 @@ model ListItem {
   episodeNumber Int?
   createdAt     DateTime     @default(now())
   updatedAt     DateTime     @updatedAt
+}
+
+model FlexgetIntegration {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int      @unique
+  baseUrl   String
+  username  String
+  password  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model ListIntegration {
+  id            Int      @id @default(autoincrement())
+  list          List     @relation(fields: [listId], references: [id], onDelete: Cascade)
+  listId        Int      @unique
+  entryListName String
+  remoteListId  Int
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 }
 
 enum ListItemType {

--- a/packages/backend/src/auth/auth-routes.ts
+++ b/packages/backend/src/auth/auth-routes.ts
@@ -30,7 +30,7 @@ export const authRoutes: FastifyPluginCallbackZod = (fastify, _options, done) =>
     reply.setCookie('velara_token', token, {
       httpOnly: true,
       path: '/',
-      sameSite: 'lax',
+      sameSite: 'none',
       secure: !config.isDevelopment,
       maxAge: COOKIE_MAX_AGE_SECONDS,
     });
@@ -54,7 +54,7 @@ export const authRoutes: FastifyPluginCallbackZod = (fastify, _options, done) =>
     reply.setCookie('velara_token', token, {
       httpOnly: true,
       path: '/',
-      sameSite: 'lax',
+      sameSite: 'none',
       secure: !config.isDevelopment,
       maxAge: COOKIE_MAX_AGE_SECONDS,
     });
@@ -63,7 +63,11 @@ export const authRoutes: FastifyPluginCallbackZod = (fastify, _options, done) =>
   });
 
   fastify.post('/logout', async (_request, reply) => {
-    reply.clearCookie('velara_token', { path: '/' });
+    reply.clearCookie('velara_token', {
+      path: '/',
+      sameSite: 'none',
+      secure: !config.isDevelopment,
+    });
     return reply.send({ success: true });
   });
 

--- a/packages/backend/src/flexget/flexget-routes.ts
+++ b/packages/backend/src/flexget/flexget-routes.ts
@@ -1,0 +1,60 @@
+import type { FastifyPluginCallbackZod } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { authenticate } from '../auth/auth-middleware.js';
+import { createFlexgetService } from './flexget-service.js';
+
+const integrationBodySchema = z.object({
+  baseUrl: z.string().url(),
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+export const flexgetRoutes: FastifyPluginCallbackZod = (fastify, _options, done) => {
+  const flexgetService = createFlexgetService({ logger: fastify.log });
+
+  fastify.get('/integration', { preHandler: authenticate }, async (request, reply) => {
+    const integration = await flexgetService.getIntegration(request.user.userId);
+    if (!integration) {
+      return reply.code(404).send({ error: 'Flexget integration not configured' });
+    }
+
+    return reply.send({
+      baseUrl: integration.baseUrl,
+      username: integration.username,
+      createdAt: integration.createdAt,
+      updatedAt: integration.updatedAt,
+    });
+  });
+
+  fastify.post(
+    '/integration',
+    { preHandler: authenticate, schema: { body: integrationBodySchema } },
+    async (request, reply) => {
+      const integration = await flexgetService.upsertIntegration(
+        request.user.userId,
+        request.body.baseUrl,
+        request.body.username,
+        request.body.password
+      );
+      return reply.code(201).send({
+        baseUrl: integration.baseUrl,
+        username: integration.username,
+        createdAt: integration.createdAt,
+        updatedAt: integration.updatedAt,
+      });
+    }
+  );
+
+  fastify.delete('/integration', { preHandler: authenticate }, async (request, reply) => {
+    await flexgetService.deleteIntegration(request.user.userId);
+    return reply.code(204).send();
+  });
+
+  fastify.get('/remote-lists', { preHandler: authenticate }, async (request, reply) => {
+    const integration = await flexgetService.ensureIntegration(request.user.userId);
+    const lists = await flexgetService.getRemoteEntryLists(integration);
+    return reply.send(lists);
+  });
+
+  done();
+};

--- a/packages/backend/src/flexget/flexget-service.ts
+++ b/packages/backend/src/flexget/flexget-service.ts
@@ -1,0 +1,214 @@
+import got from 'got';
+import { CookieJar } from 'tough-cookie';
+import type { FastifyBaseLogger } from 'fastify';
+import type { Logger } from 'pino';
+import { HttpError } from '../lib/http-error.js';
+import { LOGGER, config } from '../registry.js';
+import { prisma } from '../lib/prisma.js';
+
+type ServiceLogger = Logger | FastifyBaseLogger;
+
+interface ServiceOptions {
+  logger?: ServiceLogger;
+}
+
+export interface FlexgetIntegrationRecord {
+  id: number;
+  userId: number;
+  baseUrl: string;
+  username: string;
+  password: string;
+}
+
+export interface FlexgetEntryList {
+  id: number;
+  name: string;
+  added_on?: string;
+}
+
+export interface FlexgetEntryPayload {
+  title: string;
+  original_url: string;
+  [key: string]: unknown;
+}
+
+export function createFlexgetService(options?: ServiceOptions) {
+  const serviceLogger = options?.logger ?? LOGGER;
+  const localLogger = (context: string) =>
+    serviceLogger.child({ module: 'flexget-service', context });
+
+  function normalizeBaseUrl(rawBaseUrl: string) {
+    const trimmed = rawBaseUrl.replace(/\/+$|^\s+|\s+$/g, '');
+    return trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
+  }
+
+  function createClient(integration: FlexgetIntegrationRecord) {
+    const logger = localLogger('createClient');
+    const prefixUrl = normalizeBaseUrl(integration.baseUrl);
+    const cookieJar = new CookieJar();
+
+    logger.debug({ prefixUrl, username: integration.username }, 'Creating Flexget client');
+
+    return got.extend({
+      prefixUrl,
+      responseType: 'json',
+      headers: { Accept: 'application/json' },
+      cookieJar,
+      throwHttpErrors: false,
+      https: {
+        rejectUnauthorized: !config.FLEXGET_ALLOW_INSECURE_TLS,
+      },
+    });
+  }
+
+  async function authenticateClient(integration: FlexgetIntegrationRecord) {
+    const logger = localLogger('authenticateClient');
+    const client = createClient(integration);
+
+    const response = await client.post('auth/login/', {
+      json: { username: integration.username, password: integration.password },
+    });
+
+    if (response.statusCode !== 200) {
+      logger.warn({ statusCode: response.statusCode, body: response.body }, 'Flexget login failed');
+      if (response.statusCode === 401) {
+        throw new HttpError('Invalid Flexget credentials', { statusCode: 401 });
+      }
+      throw new HttpError('Failed to authenticate with Flexget', { statusCode: 502 });
+    }
+
+    return client;
+  }
+
+  async function getRemoteEntryLists(integration: FlexgetIntegrationRecord) {
+    const logger = localLogger('getRemoteEntryLists');
+    const client = await authenticateClient(integration);
+
+    const response = await client.get('entry_list/');
+    if (response.statusCode !== 200) {
+      logger.error(
+        { statusCode: response.statusCode, body: response.body },
+        'Failed to fetch remote entry lists'
+      );
+      throw new HttpError('Failed to fetch Flexget entry lists', { statusCode: 502 });
+    }
+
+    return response.body as FlexgetEntryList[];
+  }
+
+  async function getRemoteEntryListByName(
+    integration: FlexgetIntegrationRecord,
+    name: string
+  ): Promise<FlexgetEntryList | null> {
+    const lists = await getRemoteEntryLists(integration);
+    return lists.find(list => list.name === name) ?? null;
+  }
+
+  async function createRemoteEntryList(
+    integration: FlexgetIntegrationRecord,
+    name: string
+  ): Promise<FlexgetEntryList> {
+    const logger = localLogger('createRemoteEntryList');
+    const client = await authenticateClient(integration);
+
+    const response = await client.post('entry_list/', {
+      json: { name },
+    });
+
+    if (![200, 201].includes(response.statusCode)) {
+      logger.error(
+        { statusCode: response.statusCode, body: response.body },
+        'Failed to create remote entry list'
+      );
+      throw new HttpError('Failed to create Flexget entry list', { statusCode: 502 });
+    }
+
+    return response.body as unknown as FlexgetEntryList;
+  }
+
+  async function getOrCreateRemoteEntryList(
+    integration: FlexgetIntegrationRecord,
+    name: string
+  ): Promise<FlexgetEntryList> {
+    const existing = await getRemoteEntryListByName(integration, name);
+    if (existing) {
+      return existing;
+    }
+    return createRemoteEntryList(integration, name);
+  }
+
+  async function pushEntryToRemoteList(
+    integration: FlexgetIntegrationRecord,
+    remoteListId: number,
+    payload: FlexgetEntryPayload
+  ): Promise<void> {
+    const logger = localLogger('pushEntryToRemoteList');
+    const client = await authenticateClient(integration);
+
+    const response = await client.post(`entry_list/${remoteListId}/entries/`, {
+      json: payload,
+    });
+
+    if (![200, 201].includes(response.statusCode)) {
+      logger.error(
+        { statusCode: response.statusCode, body: response.body },
+        'Failed to push entry to Flexget'
+      );
+      if (response.statusCode === 404) {
+        throw new HttpError('Flexget list not found', { statusCode: 404 });
+      }
+      throw new HttpError('Failed to push item to Flexget entry list', { statusCode: 502 });
+    }
+  }
+
+  async function getIntegration(userId: number) {
+    const logger = localLogger('getIntegration');
+    logger.debug({ userId }, 'Fetching Flexget integration config');
+
+    return prisma.flexgetIntegration.findUnique({ where: { userId } });
+  }
+
+  async function upsertIntegration(
+    userId: number,
+    baseUrl: string,
+    username: string,
+    password: string
+  ) {
+    const logger = localLogger('upsertIntegration');
+    logger.debug({ userId, baseUrl, username }, 'Saving Flexget integration');
+
+    const integration = await prisma.flexgetIntegration.upsert({
+      where: { userId },
+      create: { userId, baseUrl, username, password },
+      update: { baseUrl, username, password },
+    });
+
+    await getRemoteEntryLists(integration);
+    return integration;
+  }
+
+  async function deleteIntegration(userId: number) {
+    const logger = localLogger('deleteIntegration');
+    logger.debug({ userId }, 'Deleting Flexget integration');
+
+    await prisma.flexgetIntegration.deleteMany({ where: { userId } });
+  }
+
+  async function ensureIntegration(userId: number) {
+    const integration = await getIntegration(userId);
+    if (!integration) {
+      throw new HttpError('Flexget integration is not configured', { statusCode: 404 });
+    }
+    return integration;
+  }
+
+  return {
+    getIntegration,
+    upsertIntegration,
+    deleteIntegration,
+    ensureIntegration,
+    getRemoteEntryLists,
+    getOrCreateRemoteEntryList,
+    pushEntryToRemoteList,
+  };
+}

--- a/packages/backend/src/flexget/flexget-service.ts
+++ b/packages/backend/src/flexget/flexget-service.ts
@@ -26,6 +26,15 @@ export interface FlexgetEntryList {
   added_on?: string;
 }
 
+export interface FlexgetEntryListEntry {
+  id: number;
+  name?: string;
+  added_on?: string;
+  title?: string;
+  original_url?: string;
+  entry?: Record<string, unknown>;
+}
+
 export interface FlexgetEntryPayload {
   title: string;
   original_url: string;
@@ -141,7 +150,7 @@ export function createFlexgetService(options?: ServiceOptions) {
     integration: FlexgetIntegrationRecord,
     remoteListId: number,
     payload: FlexgetEntryPayload
-  ): Promise<void> {
+  ): Promise<FlexgetEntryListEntry> {
     const logger = localLogger('pushEntryToRemoteList');
     const client = await authenticateClient(integration);
 
@@ -158,6 +167,34 @@ export function createFlexgetService(options?: ServiceOptions) {
         throw new HttpError('Flexget list not found', { statusCode: 404 });
       }
       throw new HttpError('Failed to push item to Flexget entry list', { statusCode: 502 });
+    }
+
+    return response.body as unknown as FlexgetEntryListEntry;
+  }
+
+  async function deleteEntryFromRemoteList(
+    integration: FlexgetIntegrationRecord,
+    remoteListId: number,
+    remoteEntryId: number
+  ): Promise<void> {
+    const logger = localLogger('deleteEntryFromRemoteList');
+    const client = await authenticateClient(integration);
+
+    const response = await client.delete(`entry_list/${remoteListId}/entries/${remoteEntryId}/`);
+    if (response.statusCode === 404) {
+      logger.warn(
+        { remoteListId, remoteEntryId },
+        'Flexget entry was already missing when attempting deletion'
+      );
+      return;
+    }
+
+    if (response.statusCode !== 200) {
+      logger.error(
+        { statusCode: response.statusCode, body: response.body },
+        'Failed to delete entry from Flexget'
+      );
+      throw new HttpError('Failed to delete entry from Flexget list', { statusCode: 502 });
     }
   }
 
@@ -210,5 +247,6 @@ export function createFlexgetService(options?: ServiceOptions) {
     getRemoteEntryLists,
     getOrCreateRemoteEntryList,
     pushEntryToRemoteList,
+    deleteEntryFromRemoteList,
   };
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -12,6 +12,7 @@ import { authRoutes } from './auth/auth-routes.js';
 import { movieRoutes } from './movies/movie-routes.js';
 import { tvRoutes } from './tv-shows/tv-show-routes.js';
 import { listRoutes } from './lists/list-routes.js';
+import { flexgetRoutes } from './flexget/flexget-routes.js';
 
 const logger = LOGGER.child({ module: 'index' });
 
@@ -42,8 +43,10 @@ server.setErrorHandler((error: unknown, request, reply) => {
 
 await server.register(fastifyHelmet);
 await server.register(fastifyCors, {
-  origin: config.CORS_ORIGIN,
+  origin: config.isDevelopment ? true : config.CORS_ORIGIN,
   credentials: true,
+  methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
 });
 await server.register(fastifyCookie);
 await server.register(fastifyJwt, {
@@ -58,6 +61,7 @@ await server.register(authRoutes, { prefix: '/api/auth' });
 await server.register(movieRoutes, { prefix: '/api/movies' });
 await server.register(tvRoutes, { prefix: '/api/tv' });
 await server.register(listRoutes, { prefix: '/api/lists' });
+await server.register(flexgetRoutes, { prefix: '/api/flexget' });
 
 server.get('/health', () => ({ status: 'ok' }));
 

--- a/packages/backend/src/lists/list-routes.ts
+++ b/packages/backend/src/lists/list-routes.ts
@@ -36,6 +36,10 @@ const listItemBodySchema = z.discriminatedUnion('type', [
   }),
 ]);
 
+const flexgetConnectionBodySchema = z.object({
+  entryListName: z.string().min(1).max(100),
+});
+
 export const listRoutes: FastifyPluginCallbackZod = (fastify, _options, done) => {
   fastify.get('/', { schema: { querystring: listQuerySchema } }, async (request, reply) => {
     const listService = createListService({ logger: request.log });
@@ -133,6 +137,49 @@ export const listRoutes: FastifyPluginCallbackZod = (fastify, _options, done) =>
       const { listId, itemId } = request.params;
       const listService = createListService({ logger: request.log });
       await listService.deleteItem(listId, itemId, request.user.userId);
+      return reply.code(204).send();
+    }
+  );
+
+  fastify.get(
+    '/:listId/flexget',
+    { preHandler: authenticate, schema: { params: paramsSchema } },
+    async (request, reply) => {
+      const listService = createListService({ logger: request.log });
+      const connection = await listService.getListFlexgetConnection(
+        request.params.listId,
+        request.user.userId
+      );
+      if (!connection) {
+        return reply.code(404).send({ error: 'Flexget connection not found' });
+      }
+      return reply.send(connection);
+    }
+  );
+
+  fastify.put(
+    '/:listId/flexget',
+    {
+      preHandler: authenticate,
+      schema: { params: paramsSchema, body: flexgetConnectionBodySchema },
+    },
+    async (request, reply) => {
+      const listService = createListService({ logger: request.log });
+      const connection = await listService.connectListToFlexget(
+        request.params.listId,
+        request.body.entryListName,
+        request.user.userId
+      );
+      return reply.send(connection);
+    }
+  );
+
+  fastify.delete(
+    '/:listId/flexget',
+    { preHandler: authenticate, schema: { params: paramsSchema } },
+    async (request, reply) => {
+      const listService = createListService({ logger: request.log });
+      await listService.disconnectListFromFlexget(request.params.listId, request.user.userId);
       return reply.code(204).send();
     }
   );

--- a/packages/backend/src/lists/list-service.spec.ts
+++ b/packages/backend/src/lists/list-service.spec.ts
@@ -12,8 +12,42 @@ const createMock = vi.fn();
 const updateManyMock = vi.fn();
 const deleteManyMock = vi.fn();
 const listItemCreateMock = vi.fn();
+const listIntegrationUpsertMock = vi.fn();
+const listIntegrationDeleteManyMock = vi.fn();
+const ensureIntegrationMock = vi.fn().mockResolvedValue({
+  id: 1,
+  userId: 1,
+  baseUrl: 'http://localhost',
+  username: 'user',
+  password: 'pass',
+});
+const getOrCreateRemoteEntryListMock = vi.fn().mockResolvedValue({ id: 12, name: 'Remote list' });
+const pushEntryToRemoteListMock = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('../registry.js', () => ({ LOGGER: loggerMock }));
+vi.mock('../registry.js', () => ({
+  LOGGER: loggerMock,
+  config: { TMDB_API_KEY: 'fake-key' },
+}));
+const tmdbGetMock = vi.fn().mockReturnValue({
+  json: vi.fn().mockResolvedValue({
+    title: 'Mock Movie',
+    original_title: 'Mock Movie',
+    name: 'Mock Movie',
+    external_ids: { imdb_id: 'tt0000001', tvdb_id: 12345 },
+  }),
+});
+
+vi.mock('../movies/tmdb-client.js', () => ({
+  tmdbClient: { get: tmdbGetMock },
+}));
+
+vi.mock('../flexget/flexget-service.js', () => ({
+  createFlexgetService: () => ({
+    ensureIntegration: ensureIntegrationMock,
+    getOrCreateRemoteEntryList: getOrCreateRemoteEntryListMock,
+    pushEntryToRemoteList: pushEntryToRemoteListMock,
+  }),
+}));
 vi.mock('../lib/prisma.js', () => ({
   prisma: {
     list: {
@@ -26,6 +60,10 @@ vi.mock('../lib/prisma.js', () => ({
     listItem: {
       create: listItemCreateMock,
       deleteMany: deleteManyMock,
+    },
+    listIntegration: {
+      upsert: listIntegrationUpsertMock,
+      deleteMany: listIntegrationDeleteManyMock,
     },
   },
 }));
@@ -138,6 +176,101 @@ describe('list service', () => {
     expect(listItemCreateMock).toHaveBeenCalledWith({
       data: { listId: 4, type: 'movie', movieTmdbId: 999 },
     });
+  });
+
+  it('connects a list to a Flexget entry list', async () => {
+    findUniqueMock.mockResolvedValue({ id: 5, creatorId: 99 });
+    listIntegrationUpsertMock.mockResolvedValue({
+      id: 7,
+      listId: 5,
+      entryListName: 'Remote list',
+      remoteListId: 12,
+    });
+
+    const { createListService } = await import('./list-service.js');
+    const service = createListService({ logger: loggerMock });
+
+    expect(await service.connectListToFlexget(5, 'Remote list', 99)).toEqual({
+      id: 7,
+      listId: 5,
+      entryListName: 'Remote list',
+      remoteListId: 12,
+    });
+    expect(ensureIntegrationMock).toHaveBeenCalledWith(99);
+    expect(getOrCreateRemoteEntryListMock).toHaveBeenCalledWith(expect.any(Object), 'Remote list');
+    expect(listIntegrationUpsertMock).toHaveBeenCalledWith({
+      where: { listId: 5 },
+      create: { listId: 5, entryListName: 'Remote list', remoteListId: 12 },
+      update: { entryListName: 'Remote list', remoteListId: 12 },
+    });
+  });
+
+  it('adds an item and pushes it to a connected Flexget list', async () => {
+    findUniqueMock.mockResolvedValue({
+      id: 6,
+      creatorId: 11,
+      flexgetConnection: { entryListName: 'Remote list', remoteListId: 12 },
+    });
+    listItemCreateMock.mockResolvedValue({ id: 22, listId: 6, type: 'movie', movieTmdbId: 999 });
+
+    const { createListService } = await import('./list-service.js');
+    const service = createListService({ logger: loggerMock });
+
+    expect(await service.addItem(6, { type: 'movie', movieTmdbId: 999 }, 11)).toEqual({
+      id: 22,
+      listId: 6,
+      type: 'movie',
+      movieTmdbId: 999,
+    });
+    expect(ensureIntegrationMock).toHaveBeenCalledWith(11);
+    expect(getOrCreateRemoteEntryListMock).toHaveBeenCalledWith(
+      expect.objectContaining({}),
+      'Remote list'
+    );
+    expect(pushEntryToRemoteListMock).toHaveBeenCalledWith(
+      expect.objectContaining({}),
+      12,
+      expect.objectContaining({
+        title: expect.any(String),
+        original_url: expect.stringContaining('themoviedb.org/movie/999'),
+      })
+    );
+    expect(listItemCreateMock).toHaveBeenCalledWith({
+      data: { listId: 6, type: 'movie', movieTmdbId: 999 },
+    });
+  });
+
+  it('adds a TV series item and includes tvdb_id in the Flexget payload', async () => {
+    findUniqueMock.mockResolvedValue({
+      id: 7,
+      creatorId: 11,
+      flexgetConnection: { entryListName: 'Remote list', remoteListId: 12 },
+    });
+    listItemCreateMock.mockResolvedValue({
+      id: 23,
+      listId: 7,
+      type: 'series',
+      seriesTmdbId: '123',
+    });
+
+    const { createListService } = await import('./list-service.js');
+    const service = createListService({ logger: loggerMock });
+
+    expect(await service.addItem(7, { type: 'series', seriesTmdbId: '123' }, 11)).toEqual({
+      id: 23,
+      listId: 7,
+      type: 'series',
+      seriesTmdbId: '123',
+    });
+    expect(pushEntryToRemoteListMock).toHaveBeenCalledWith(
+      expect.objectContaining({}),
+      12,
+      expect.objectContaining({
+        title: expect.any(String),
+        original_url: expect.stringContaining('themoviedb.org/tv/123'),
+        tvdb_id: 12345,
+      })
+    );
   });
 
   it('removes an owned item from a list', async () => {

--- a/packages/backend/src/lists/list-service.spec.ts
+++ b/packages/backend/src/lists/list-service.spec.ts
@@ -11,7 +11,9 @@ const findManyMock = vi.fn();
 const createMock = vi.fn();
 const updateManyMock = vi.fn();
 const deleteManyMock = vi.fn();
+const listItemFindUniqueMock = vi.fn();
 const listItemCreateMock = vi.fn();
+const listItemDeleteMock = vi.fn();
 const listIntegrationUpsertMock = vi.fn();
 const listIntegrationDeleteManyMock = vi.fn();
 const ensureIntegrationMock = vi.fn().mockResolvedValue({
@@ -22,7 +24,8 @@ const ensureIntegrationMock = vi.fn().mockResolvedValue({
   password: 'pass',
 });
 const getOrCreateRemoteEntryListMock = vi.fn().mockResolvedValue({ id: 12, name: 'Remote list' });
-const pushEntryToRemoteListMock = vi.fn().mockResolvedValue(undefined);
+const pushEntryToRemoteListMock = vi.fn().mockResolvedValue({ id: 31, title: 'Created Entry' });
+const deleteEntryFromRemoteListMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../registry.js', () => ({
   LOGGER: loggerMock,
@@ -46,6 +49,7 @@ vi.mock('../flexget/flexget-service.js', () => ({
     ensureIntegration: ensureIntegrationMock,
     getOrCreateRemoteEntryList: getOrCreateRemoteEntryListMock,
     pushEntryToRemoteList: pushEntryToRemoteListMock,
+    deleteEntryFromRemoteList: deleteEntryFromRemoteListMock,
   }),
 }));
 vi.mock('../lib/prisma.js', () => ({
@@ -58,7 +62,9 @@ vi.mock('../lib/prisma.js', () => ({
       deleteMany: deleteManyMock,
     },
     listItem: {
+      findUnique: listItemFindUniqueMock,
       create: listItemCreateMock,
+      delete: listItemDeleteMock,
       deleteMany: deleteManyMock,
     },
     listIntegration: {
@@ -230,13 +236,18 @@ describe('list service', () => {
     expect(pushEntryToRemoteListMock).toHaveBeenCalledWith(
       expect.objectContaining({}),
       12,
-      expect.objectContaining({
+      expect.objectContaining<Record<string, unknown>>({
         title: expect.any(String),
         original_url: expect.stringContaining('themoviedb.org/movie/999'),
       })
     );
     expect(listItemCreateMock).toHaveBeenCalledWith({
-      data: { listId: 6, type: 'movie', movieTmdbId: 999 },
+      data: {
+        listId: 6,
+        type: 'movie',
+        remoteEntryId: 31,
+        movieTmdbId: 999,
+      },
     });
   });
 
@@ -265,7 +276,7 @@ describe('list service', () => {
     expect(pushEntryToRemoteListMock).toHaveBeenCalledWith(
       expect.objectContaining({}),
       12,
-      expect.objectContaining({
+      expect.objectContaining<Record<string, unknown>>({
         title: expect.any(String),
         original_url: expect.stringContaining('themoviedb.org/tv/123'),
         tvdb_id: 12345,
@@ -274,14 +285,40 @@ describe('list service', () => {
   });
 
   it('removes an owned item from a list', async () => {
-    deleteManyMock.mockResolvedValue({ count: 1 });
+    listItemFindUniqueMock.mockResolvedValue({
+      id: 77,
+      listId: 5,
+      remoteEntryId: null,
+      list: { creatorId: 11, flexgetConnection: null },
+    });
+    listItemDeleteMock.mockResolvedValue({ id: 77 });
 
     const { createListService } = await import('./list-service.js');
     const service = createListService({ logger: loggerMock });
 
     await expect(service.deleteItem(5, 77, 11)).resolves.toBeUndefined();
-    expect(deleteManyMock).toHaveBeenCalledWith({
-      where: { id: 77, listId: 5, list: { creatorId: 11 } },
+    expect(listItemDeleteMock).toHaveBeenCalledWith({ where: { id: 77 } });
+    expect(deleteEntryFromRemoteListMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes a synced item from Flexget before removing the local item', async () => {
+    listItemFindUniqueMock.mockResolvedValue({
+      id: 77,
+      listId: 5,
+      remoteEntryId: 987,
+      list: {
+        creatorId: 11,
+        flexgetConnection: { entryListName: 'Remote list', remoteListId: 12 },
+      },
     });
+    listItemDeleteMock.mockResolvedValue({ id: 77 });
+
+    const { createListService } = await import('./list-service.js');
+    const service = createListService({ logger: loggerMock });
+
+    await expect(service.deleteItem(5, 77, 11)).resolves.toBeUndefined();
+    expect(ensureIntegrationMock).toHaveBeenCalledWith(11);
+    expect(deleteEntryFromRemoteListMock).toHaveBeenCalledWith(expect.any(Object), 12, 987);
+    expect(listItemDeleteMock).toHaveBeenCalledWith({ where: { id: 77 } });
   });
 });

--- a/packages/backend/src/lists/list-service.ts
+++ b/packages/backend/src/lists/list-service.ts
@@ -3,6 +3,8 @@ import type { Logger } from 'pino';
 import { LOGGER } from '../registry.js';
 import { prisma } from '../lib/prisma.js';
 import { HttpError } from '../lib/http-error.js';
+import { tmdbClient } from '../movies/tmdb-client.js';
+import { createFlexgetService } from '../flexget/flexget-service.js';
 
 type ServiceLogger = Logger | FastifyBaseLogger;
 
@@ -21,8 +23,18 @@ type ListItemInput =
       episodeNumber: number;
     };
 
+interface OwnedListWithConnection {
+  id: number;
+  creatorId: number;
+  flexgetConnection: {
+    entryListName: string;
+    remoteListId: number;
+  } | null;
+}
+
 export function createListService(options?: ServiceOptions) {
   const serviceLogger = options?.logger ?? LOGGER;
+  const flexgetService = createFlexgetService({ logger: serviceLogger });
 
   const localLogger = (context: string) => serviceLogger.child({ module: 'list-service', context });
 
@@ -30,9 +42,13 @@ export function createListService(options?: ServiceOptions) {
     const logger = localLogger('ensureOwnedList');
     logger.debug({ listId, userId }, 'Checking list ownership');
 
-    const list = await prisma.list.findUnique({
+    const list: OwnedListWithConnection | null = await prisma.list.findUnique({
       where: { id: listId },
-      select: { id: true, creatorId: true },
+      select: {
+        id: true,
+        creatorId: true,
+        flexgetConnection: { select: { entryListName: true, remoteListId: true } },
+      },
     });
 
     if (list?.creatorId !== userId) {
@@ -40,6 +56,96 @@ export function createListService(options?: ServiceOptions) {
     }
 
     return list;
+  }
+
+  async function fetchMovieMetadata(movieTmdbId: number) {
+    try {
+      return await tmdbClient
+        .get(`movie/${movieTmdbId}`, {
+          searchParams: { append_to_response: 'external_ids' },
+        })
+        .json<{
+          title: string;
+          original_title?: string;
+          external_ids?: { imdb_id?: string | null };
+        }>();
+    } catch {
+      return {
+        title: `Movie ${movieTmdbId}`,
+        original_title: `Movie ${movieTmdbId}`,
+        external_ids: { imdb_id: null },
+      };
+    }
+  }
+
+  async function fetchTvShowMetadata(seriesTmdbId: string) {
+    try {
+      return await tmdbClient
+        .get(`tv/${seriesTmdbId}`, {
+          searchParams: { append_to_response: 'external_ids' },
+        })
+        .json<{
+          name: string;
+          external_ids?: { imdb_id?: string | null; tvdb_id?: number | null };
+        }>();
+    } catch {
+      return {
+        name: `TV show ${seriesTmdbId}`,
+        external_ids: { imdb_id: null, tvdb_id: null },
+      };
+    }
+  }
+
+  async function mapItemToFlexgetEntry(item: ListItemInput) {
+    switch (item.type) {
+      case 'movie': {
+        const movie = await fetchMovieMetadata(item.movieTmdbId);
+        return {
+          title: movie.title,
+          original_title: movie.original_title ?? movie.title,
+          original_url: `https://www.themoviedb.org/movie/${item.movieTmdbId}`,
+          imdb_id: movie.external_ids?.imdb_id ?? undefined,
+        };
+      }
+      case 'series': {
+        const show = await fetchTvShowMetadata(item.seriesTmdbId);
+        return {
+          title: show.name,
+          original_title: show.name,
+          original_url: `https://www.themoviedb.org/tv/${item.seriesTmdbId}`,
+          series_name: show.name,
+          imdb_id: show.external_ids?.imdb_id ?? undefined,
+          tvdb_id: show.external_ids?.tvdb_id ?? undefined,
+        };
+      }
+      case 'season': {
+        const show = await fetchTvShowMetadata(item.seriesTmdbId);
+        return {
+          title: `${show.name} Season ${item.seasonNumber}`,
+          original_title: `${show.name} Season ${item.seasonNumber}`,
+          original_url: `https://www.themoviedb.org/tv/${item.seriesTmdbId}/season/${item.seasonNumber}`,
+          series_name: show.name,
+          season_number: item.seasonNumber,
+          imdb_id: show.external_ids?.imdb_id ?? undefined,
+          tvdb_id: show.external_ids?.tvdb_id ?? undefined,
+        };
+      }
+      case 'episode': {
+        const show = await fetchTvShowMetadata(item.seriesTmdbId);
+        return {
+          title: `${show.name} S${item.seasonNumber}E${item.episodeNumber}`,
+          original_title: `${show.name} S${item.seasonNumber}E${item.episodeNumber}`,
+          original_url: `https://www.themoviedb.org/tv/${item.seriesTmdbId}/season/${item.seasonNumber}/episode/${item.episodeNumber}`,
+          series_name: show.name,
+          season_number: item.seasonNumber,
+          episode_number: item.episodeNumber,
+          imdb_id: show.external_ids?.imdb_id ?? undefined,
+          tvdb_id: show.external_ids?.tvdb_id ?? undefined,
+        };
+      }
+      default:
+        throw new HttpError('Unsupported list item type', { statusCode: 400 });
+    }
   }
 
   return {
@@ -73,6 +179,7 @@ export function createListService(options?: ServiceOptions) {
         include: {
           creator: { select: { id: true, username: true } },
           items: true,
+          flexgetConnection: true,
         },
       });
 
@@ -141,11 +248,69 @@ export function createListService(options?: ServiceOptions) {
       }
     },
 
+    async getListFlexgetConnection(listId: number, userId: number) {
+      const logger = localLogger('getListFlexgetConnection');
+      logger.debug({ listId, userId }, 'Fetching list Flexget connection');
+
+      const list = await ensureOwnedList(listId, userId);
+      return list.flexgetConnection;
+    },
+
+    async connectListToFlexget(listId: number, entryListName: string, userId: number) {
+      const logger = localLogger('connectListToFlexget');
+      logger.debug({ listId, entryListName, userId }, 'Connecting list to Flexget entry list');
+
+      await ensureOwnedList(listId, userId);
+      const integration = await flexgetService.ensureIntegration(userId);
+      const remoteList = await flexgetService.getOrCreateRemoteEntryList(
+        integration,
+        entryListName
+      );
+
+      return prisma.listIntegration.upsert({
+        where: { listId },
+        create: {
+          listId,
+          entryListName: remoteList.name,
+          remoteListId: remoteList.id,
+        },
+        update: {
+          entryListName: remoteList.name,
+          remoteListId: remoteList.id,
+        },
+      });
+    },
+
+    async disconnectListFromFlexget(listId: number, userId: number) {
+      const logger = localLogger('disconnectListFromFlexget');
+      logger.debug({ listId, userId }, 'Disconnecting list from Flexget');
+
+      await ensureOwnedList(listId, userId);
+      await prisma.listIntegration.deleteMany({ where: { listId } });
+    },
+
     async addItem(listId: number, item: ListItemInput, userId: number) {
       const logger = localLogger('addItem');
       logger.debug({ listId, item, userId }, 'Adding item to list');
 
-      await ensureOwnedList(listId, userId);
+      const list = await ensureOwnedList(listId, userId);
+      if (list.flexgetConnection) {
+        const integration = await flexgetService.ensureIntegration(userId);
+        const remoteList = await flexgetService.getOrCreateRemoteEntryList(
+          integration,
+          list.flexgetConnection.entryListName
+        );
+
+        if (remoteList.id !== list.flexgetConnection.remoteListId) {
+          await prisma.listIntegration.update({
+            where: { listId },
+            data: { remoteListId: remoteList.id, entryListName: remoteList.name },
+          });
+        }
+
+        const entryPayload = await mapItemToFlexgetEntry(item);
+        await flexgetService.pushEntryToRemoteList(integration, remoteList.id, entryPayload);
+      }
 
       return prisma.listItem.create({
         data: {

--- a/packages/backend/src/lists/list-service.ts
+++ b/packages/backend/src/lists/list-service.ts
@@ -148,6 +148,26 @@ export function createListService(options?: ServiceOptions) {
     }
   }
 
+  function buildListItemData(listId: number, item: ListItemInput, remoteEntryId?: number) {
+    return {
+      listId,
+      type: item.type,
+      ...(remoteEntryId !== undefined ? { remoteEntryId } : {}),
+      ...(item.type === 'movie' ? { movieTmdbId: item.movieTmdbId } : {}),
+      ...(item.type === 'series' ? { seriesTmdbId: item.seriesTmdbId } : {}),
+      ...(item.type === 'season'
+        ? { seriesTmdbId: item.seriesTmdbId, seasonNumber: item.seasonNumber }
+        : {}),
+      ...(item.type === 'episode'
+        ? {
+            seriesTmdbId: item.seriesTmdbId,
+            seasonNumber: item.seasonNumber,
+            episodeNumber: item.episodeNumber,
+          }
+        : {}),
+    };
+  }
+
   return {
     async getLists(userId: number | undefined, mine = false) {
       const logger = localLogger('getLists');
@@ -309,26 +329,19 @@ export function createListService(options?: ServiceOptions) {
         }
 
         const entryPayload = await mapItemToFlexgetEntry(item);
-        await flexgetService.pushEntryToRemoteList(integration, remoteList.id, entryPayload);
+        const remoteEntry = await flexgetService.pushEntryToRemoteList(
+          integration,
+          remoteList.id,
+          entryPayload
+        );
+
+        return prisma.listItem.create({
+          data: buildListItemData(listId, item, remoteEntry.id),
+        });
       }
 
       return prisma.listItem.create({
-        data: {
-          listId,
-          type: item.type,
-          ...(item.type === 'movie' ? { movieTmdbId: item.movieTmdbId } : {}),
-          ...(item.type === 'series' ? { seriesTmdbId: item.seriesTmdbId } : {}),
-          ...(item.type === 'season'
-            ? { seriesTmdbId: item.seriesTmdbId, seasonNumber: item.seasonNumber }
-            : {}),
-          ...(item.type === 'episode'
-            ? {
-                seriesTmdbId: item.seriesTmdbId,
-                seasonNumber: item.seasonNumber,
-                episodeNumber: item.episodeNumber,
-              }
-            : {}),
-        },
+        data: buildListItemData(listId, item),
       });
     },
 
@@ -336,19 +349,37 @@ export function createListService(options?: ServiceOptions) {
       const logger = localLogger('deleteItem');
       logger.debug({ listId, itemId, userId }, 'Removing item from list');
 
-      const result = await prisma.listItem.deleteMany({
-        where: {
-          id: itemId,
-          listId,
+      const item = await prisma.listItem.findUnique({
+        where: { id: itemId },
+        select: {
+          id: true,
+          listId: true,
+          remoteEntryId: true,
           list: {
-            creatorId: userId,
+            select: {
+              creatorId: true,
+              flexgetConnection: {
+                select: { entryListName: true, remoteListId: true },
+              },
+            },
           },
         },
       });
 
-      if (result.count === 0) {
+      if (item?.listId !== listId || item.list?.creatorId !== userId) {
         throw new HttpError('List item not found', { statusCode: 404 });
       }
+
+      if (item.list.flexgetConnection?.remoteListId && item.remoteEntryId != null) {
+        const integration = await flexgetService.ensureIntegration(userId);
+        await flexgetService.deleteEntryFromRemoteList(
+          integration,
+          item.list.flexgetConnection.remoteListId,
+          item.remoteEntryId
+        );
+      }
+
+      await prisma.listItem.delete({ where: { id: itemId } });
     },
   };
 }

--- a/packages/backend/src/schema.ts
+++ b/packages/backend/src/schema.ts
@@ -13,6 +13,7 @@ export const envSchema = z
     JWT_SECRET: z.string().min(32),
     PORT: z.coerce.number().int().positive().default(3070),
     CORS_ORIGIN: z.string().default('http://localhost:5173'),
+    FLEXGET_ALLOW_INSECURE_TLS: z.coerce.boolean().default(false),
   })
   .transform(raw => ({
     NODE_ENV: raw.NODE_ENV,
@@ -22,6 +23,7 @@ export const envSchema = z
     JWT_SECRET: raw.JWT_SECRET,
     PORT: raw.PORT,
     CORS_ORIGIN: raw.CORS_ORIGIN,
+    FLEXGET_ALLOW_INSECURE_TLS: raw.FLEXGET_ALLOW_INSECURE_TLS,
     isDevelopment: raw.NODE_ENV !== 'production',
   }));
 

--- a/packages/frontend/src/pages/lists/ListDetailsPage.tsx
+++ b/packages/frontend/src/pages/lists/ListDetailsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { ArrowLeft, Trash2, Plus, Edit3 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -16,8 +17,10 @@ import { useAuth } from '@/hooks/useAuth';
 import ListItemCard from '@/components/lists/ListItemCard';
 import {
   addListItem,
+  connectListToFlexget,
   deleteList,
   deleteListItem,
+  disconnectListFromFlexget,
   fetchListDetails,
   updateList,
 } from '@/services/lists-api';
@@ -39,6 +42,9 @@ export default function ListDetailsPage() {
   const [seriesTmdbId, setSeriesTmdbId] = useState('');
   const [seasonNumber, setSeasonNumber] = useState('');
   const [episodeNumber, setEpisodeNumber] = useState('');
+  const [entryListName, setEntryListName] = useState('');
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
 
   const isOwner = Boolean(user && list && user.id === list.creator.id);
 
@@ -53,6 +59,7 @@ export default function ListDetailsPage() {
         setList(data);
         setTitle(data.title);
         setDescription(data.description ?? '');
+        setEntryListName(data.flexgetConnection?.entryListName ?? '');
       })
       .catch(() => setError('Unable to load list.'))
       .finally(() => setIsLoading(false));
@@ -131,6 +138,48 @@ export default function ListDetailsPage() {
       );
     } catch {
       setError('Could not remove item.');
+    }
+  };
+
+  const handleConnectToFlexget = async () => {
+    if (!list) return;
+    if (!entryListName.trim()) {
+      setError('Entry list name is required to connect.');
+      return;
+    }
+
+    setIsConnecting(true);
+    setError(null);
+
+    try {
+      await connectListToFlexget(list.id, entryListName.trim());
+      const updated = await fetchListDetails(list.id);
+      setList(updated);
+      toast.success('List connected to Flexget entry list.');
+    } catch {
+      setError('Could not connect list to Flexget. Check integration settings.');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleDisconnectFromFlexget = async () => {
+    if (!list || !list.flexgetConnection) return;
+    if (!window.confirm('Disconnect this list from Flexget?')) return;
+
+    setIsDisconnecting(true);
+    setError(null);
+
+    try {
+      await disconnectListFromFlexget(list.id);
+      const updated = await fetchListDetails(list.id);
+      setList(updated);
+      setEntryListName('');
+      toast.success('List disconnected from Flexget.');
+    } catch {
+      setError('Could not disconnect list from Flexget.');
+    } finally {
+      setIsDisconnecting(false);
     }
   };
 
@@ -318,6 +367,66 @@ export default function ListDetailsPage() {
                   </Button>
                 </div>
               ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Flexget connection</CardTitle>
+              <CardDescription>
+                Connect this list to a Flexget entry list so new items are pushed automatically.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {list.flexgetConnection ? (
+                <div className="rounded-lg border border-muted p-4">
+                  <p className="text-sm text-muted-foreground">Connected entry list</p>
+                  <p className="font-medium">{list.flexgetConnection.entryListName}</p>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-muted p-4">
+                  <p className="text-sm text-muted-foreground">
+                    This list is not connected to a Flexget entry list.
+                  </p>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="entry-list-name">
+                  Flexget entry list name
+                </label>
+                <Input
+                  id="entry-list-name"
+                  value={entryListName}
+                  onChange={event => setEntryListName(event.target.value)}
+                  placeholder="Example: My Downloads"
+                  disabled={!isOwner}
+                />
+              </div>
+
+              {!isOwner ? (
+                <p className="text-sm text-muted-foreground">
+                  Only the list owner can connect this list to Flexget.
+                </p>
+              ) : null}
+
+              <div className="flex gap-2 flex-wrap">
+                <Button onClick={handleConnectToFlexget} disabled={!isOwner || isConnecting}>
+                  {isConnecting
+                    ? 'Connecting…'
+                    : list.flexgetConnection
+                      ? 'Update connection'
+                      : 'Connect list'}
+                </Button>
+                {list.flexgetConnection ? (
+                  <Button
+                    variant="destructive"
+                    onClick={handleDisconnectFromFlexget}
+                    disabled={!isOwner || isDisconnecting}>
+                    {isDisconnecting ? 'Disconnecting…' : 'Disconnect'}
+                  </Button>
+                ) : null}
+              </div>
             </CardContent>
           </Card>
 

--- a/packages/frontend/src/pages/profile/ProfilePage.tsx
+++ b/packages/frontend/src/pages/profile/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useRef, useState } from 'react';
+import { type ChangeEvent, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -14,6 +14,12 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/hooks/useAuth';
+import {
+  deleteFlexgetIntegration,
+  fetchFlexgetIntegration,
+  saveFlexgetIntegration,
+  type FlexgetIntegration,
+} from '@/services/flexget-api';
 import { importMovies, type ImportProvider, type ImportSummary } from '@/services/user-data-api';
 import { importTvShows } from '@/services/user-tv-data-api';
 
@@ -25,6 +31,13 @@ export default function ProfilePage() {
   const [importType, setImportType] = useState<'ratings' | 'comments'>('ratings');
   const [isLoading, setIsLoading] = useState(false);
   const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const [currentIntegration, setCurrentIntegration] = useState<FlexgetIntegration | null>(null);
+  const [baseUrl, setBaseUrl] = useState('');
+  const [flexgetUsername, setFlexgetUsername] = useState('');
+  const [flexgetPassword, setFlexgetPassword] = useState('');
+  const [isIntegrationLoading, setIsIntegrationLoading] = useState(true);
+  const [isSavingIntegration, setIsSavingIntegration] = useState(false);
+  const [isRemovingIntegration, setIsRemovingIntegration] = useState(false);
 
   const tvFileInputRef = useRef<HTMLInputElement | null>(null);
   const [tvContent, setTvContent] = useState('');
@@ -111,6 +124,64 @@ export default function ProfilePage() {
       toast.error('Import failed. Check the file format and try again.');
     } finally {
       setTvIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    setIsIntegrationLoading(true);
+    fetchFlexgetIntegration()
+      .then(data => {
+        setCurrentIntegration(data);
+        setBaseUrl(data.baseUrl);
+        setFlexgetUsername(data.username);
+      })
+      .catch(() => {
+        setCurrentIntegration(null);
+      })
+      .finally(() => {
+        setIsIntegrationLoading(false);
+      });
+  }, [user]);
+
+  const handleSaveIntegration = async () => {
+    setIsSavingIntegration(true);
+    try {
+      const saved = await saveFlexgetIntegration({
+        baseUrl: baseUrl.trim(),
+        username: flexgetUsername.trim(),
+        password: flexgetPassword,
+      });
+      setCurrentIntegration(saved);
+      setFlexgetPassword('');
+      toast.success('Flexget integration saved.');
+    } catch {
+      toast.error('Unable to save Flexget integration.');
+    } finally {
+      setIsSavingIntegration(false);
+    }
+  };
+
+  const handleRemoveIntegration = async () => {
+    if (!window.confirm('Remove saved Flexget integration?')) {
+      return;
+    }
+
+    setIsRemovingIntegration(true);
+    try {
+      await deleteFlexgetIntegration();
+      setCurrentIntegration(null);
+      setBaseUrl('');
+      setFlexgetUsername('');
+      setFlexgetPassword('');
+      toast.success('Flexget integration removed.');
+    } catch {
+      toast.error('Unable to remove Flexget integration.');
+    } finally {
+      setIsRemovingIntegration(false);
     }
   };
 
@@ -294,6 +365,75 @@ export default function ProfilePage() {
               )}
             </div>
           ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Flexget integration</CardTitle>
+          <CardDescription>
+            Save your Flexget host and credentials here so this account can connect lists to a
+            Flexget entry list.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="flexget-base-url">Flexget URL</Label>
+            <Input
+              id="flexget-base-url"
+              type="url"
+              value={baseUrl}
+              onChange={event => setBaseUrl(event.target.value)}
+              placeholder="https://flexget.local"
+              disabled={isIntegrationLoading}
+            />
+          </div>
+
+          <div className="grid gap-2 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="flexget-username">Username</Label>
+              <Input
+                id="flexget-username"
+                value={flexgetUsername}
+                onChange={event => setFlexgetUsername(event.target.value)}
+                disabled={isIntegrationLoading}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="flexget-password">Password</Label>
+              <Input
+                id="flexget-password"
+                type="password"
+                value={flexgetPassword}
+                onChange={event => setFlexgetPassword(event.target.value)}
+                disabled={isIntegrationLoading}
+              />
+            </div>
+          </div>
+
+          {currentIntegration ? (
+            <div className="rounded-lg border border-muted p-4">
+              <p className="text-sm text-muted-foreground">Saved integration</p>
+              <p className="font-medium">{currentIntegration.baseUrl}</p>
+              <p className="text-sm">Username: {currentIntegration.username}</p>
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={handleSaveIntegration}
+              disabled={isSavingIntegration || isIntegrationLoading}>
+              {currentIntegration ? 'Update integration' : 'Save integration'}
+            </Button>
+            {currentIntegration ? (
+              <Button
+                variant="destructive"
+                onClick={handleRemoveIntegration}
+                disabled={isRemovingIntegration || isIntegrationLoading}>
+                Remove integration
+              </Button>
+            ) : null}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/packages/frontend/src/services/flexget-api.ts
+++ b/packages/frontend/src/services/flexget-api.ts
@@ -1,0 +1,58 @@
+import { apiRequest } from './api-client';
+
+export interface FlexgetIntegration {
+  baseUrl: string;
+  username: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FlexgetIntegrationInput {
+  baseUrl: string;
+  username: string;
+  password: string;
+}
+
+export interface FlexgetConnection {
+  entryListName: string;
+  remoteListId: number;
+}
+
+export async function fetchFlexgetIntegration(): Promise<FlexgetIntegration> {
+  return apiRequest<FlexgetIntegration>('/api/flexget/integration');
+}
+
+export async function saveFlexgetIntegration(
+  payload: FlexgetIntegrationInput
+): Promise<FlexgetIntegration> {
+  return apiRequest<FlexgetIntegration>('/api/flexget/integration', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteFlexgetIntegration(): Promise<void> {
+  return apiRequest<void>('/api/flexget/integration', {
+    method: 'DELETE',
+  });
+}
+
+export async function fetchFlexgetRemoteLists(): Promise<FlexgetConnection[]> {
+  return apiRequest<FlexgetConnection[]>('/api/flexget/remote-lists');
+}
+
+export async function connectListToFlexget(
+  listId: number,
+  entryListName: string
+): Promise<FlexgetConnection> {
+  return apiRequest<FlexgetConnection>(`/api/lists/${listId}/flexget`, {
+    method: 'PUT',
+    body: JSON.stringify({ entryListName }),
+  });
+}
+
+export async function disconnectListFromFlexget(listId: number): Promise<void> {
+  return apiRequest<void>(`/api/lists/${listId}/flexget`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/frontend/src/services/lists-api.ts
+++ b/packages/frontend/src/services/lists-api.ts
@@ -52,3 +52,19 @@ export async function deleteListItem(listId: number, itemId: number): Promise<vo
     method: 'DELETE',
   });
 }
+
+export async function connectListToFlexget(
+  listId: number,
+  entryListName: string
+): Promise<{ entryListName: string; remoteListId: number }> {
+  return apiRequest(`/api/lists/${listId}/flexget`, {
+    method: 'PUT',
+    body: JSON.stringify({ entryListName }),
+  });
+}
+
+export async function disconnectListFromFlexget(listId: number): Promise<void> {
+  return apiRequest<void>(`/api/lists/${listId}/flexget`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/frontend/src/types/list.ts
+++ b/packages/frontend/src/types/list.ts
@@ -24,8 +24,14 @@ export interface ListItem {
   updatedAt: string;
 }
 
+export interface ListFlexgetConnection {
+  entryListName: string;
+  remoteListId: number;
+}
+
 export interface ListDetails extends ListSummary {
   items: ListItem[];
+  flexgetConnection?: ListFlexgetConnection | null;
 }
 
 export interface CreateListPayload {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3070',
         changeOrigin: true,
+        secure: false,
       },
     },
   },


### PR DESCRIPTION
**PR description**

- Added backend Flexget integration support for syncing Velara lists with remote Flexget entry lists.
- Persist `remoteEntryId` for synced list items so remote entries can be tracked.
- Delete the corresponding Flexget entry before removing a local list item.
- Added backend tests covering unsynced deletion and synced deletion flows.
- Updated frontend list details, profile page, and API clients to support Flexget connection state and list syncing.