### PR TITLE
feat: import Flexget entry lists into Velara #31

### DIFF
--- a/packages/backend/src/flexget/flexget-routes.ts
+++ b/packages/backend/src/flexget/flexget-routes.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginCallbackZod } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { authenticate } from '../auth/auth-middleware.js';
 import { createFlexgetService } from './flexget-service.js';
+import { createListService } from '../lists/list-service.js';
 
 const integrationBodySchema = z.object({
   baseUrl: z.string().url(),
@@ -55,6 +56,23 @@ export const flexgetRoutes: FastifyPluginCallbackZod = (fastify, _options, done)
     const lists = await flexgetService.getRemoteEntryLists(integration);
     return reply.send(lists);
   });
+
+  const importFlexgetListBodySchema = z.object({
+    remoteListId: z.coerce.number().int().positive(),
+  });
+
+  fastify.post(
+    '/import',
+    { preHandler: authenticate, schema: { body: importFlexgetListBodySchema } },
+    async (request, reply) => {
+      const listService = createListService({ logger: request.log });
+      const list = await listService.importFlexgetList(
+        request.body.remoteListId,
+        request.user.userId
+      );
+      return reply.code(201).send(list);
+    }
+  );
 
   done();
 };

--- a/packages/backend/src/flexget/flexget-service.ts
+++ b/packages/backend/src/flexget/flexget-service.ts
@@ -105,6 +105,28 @@ export function createFlexgetService(options?: ServiceOptions) {
     return response.body as FlexgetEntryList[];
   }
 
+  async function getRemoteEntryListEntries(
+    integration: FlexgetIntegrationRecord,
+    remoteListId: number
+  ) {
+    const logger = localLogger('getRemoteEntryListEntries');
+    const client = await authenticateClient(integration);
+
+    const response = await client.get(`entry_list/${remoteListId}/entries/`);
+    if (response.statusCode !== 200) {
+      logger.error(
+        { statusCode: response.statusCode, body: response.body, remoteListId },
+        'Failed to fetch remote entry list entries'
+      );
+      if (response.statusCode === 404) {
+        throw new HttpError('Flexget entry list not found', { statusCode: 404 });
+      }
+      throw new HttpError('Failed to fetch Flexget entry list entries', { statusCode: 502 });
+    }
+
+    return response.body as FlexgetEntryListEntry[];
+  }
+
   async function getRemoteEntryListByName(
     integration: FlexgetIntegrationRecord,
     name: string
@@ -246,6 +268,7 @@ export function createFlexgetService(options?: ServiceOptions) {
     ensureIntegration,
     getRemoteEntryLists,
     getOrCreateRemoteEntryList,
+    getRemoteEntryListEntries,
     pushEntryToRemoteList,
     deleteEntryFromRemoteList,
   };

--- a/packages/backend/src/lists/list-service.spec.ts
+++ b/packages/backend/src/lists/list-service.spec.ts
@@ -11,11 +11,13 @@ const findManyMock = vi.fn();
 const createMock = vi.fn();
 const updateManyMock = vi.fn();
 const deleteManyMock = vi.fn();
+const findFirstMock = vi.fn();
 const listItemFindUniqueMock = vi.fn();
 const listItemCreateMock = vi.fn();
 const listItemDeleteMock = vi.fn();
 const listIntegrationUpsertMock = vi.fn();
 const listIntegrationDeleteManyMock = vi.fn();
+const prismaTransactionMock = vi.fn();
 const ensureIntegrationMock = vi.fn().mockResolvedValue({
   id: 1,
   userId: 1,
@@ -23,6 +25,8 @@ const ensureIntegrationMock = vi.fn().mockResolvedValue({
   username: 'user',
   password: 'pass',
 });
+const getRemoteEntryListsMock = vi.fn().mockResolvedValue([]);
+const getRemoteEntryListEntriesMock = vi.fn().mockResolvedValue([]);
 const getOrCreateRemoteEntryListMock = vi.fn().mockResolvedValue({ id: 12, name: 'Remote list' });
 const pushEntryToRemoteListMock = vi.fn().mockResolvedValue({ id: 31, title: 'Created Entry' });
 const deleteEntryFromRemoteListMock = vi.fn().mockResolvedValue(undefined);
@@ -47,6 +51,8 @@ vi.mock('../movies/tmdb-client.js', () => ({
 vi.mock('../flexget/flexget-service.js', () => ({
   createFlexgetService: () => ({
     ensureIntegration: ensureIntegrationMock,
+    getRemoteEntryLists: getRemoteEntryListsMock,
+    getRemoteEntryListEntries: getRemoteEntryListEntriesMock,
     getOrCreateRemoteEntryList: getOrCreateRemoteEntryListMock,
     pushEntryToRemoteList: pushEntryToRemoteListMock,
     deleteEntryFromRemoteList: deleteEntryFromRemoteListMock,
@@ -56,6 +62,7 @@ vi.mock('../lib/prisma.js', () => ({
   prisma: {
     list: {
       findUnique: findUniqueMock,
+      findFirst: findFirstMock,
       findMany: findManyMock,
       create: createMock,
       updateMany: updateManyMock,
@@ -71,6 +78,7 @@ vi.mock('../lib/prisma.js', () => ({
       upsert: listIntegrationUpsertMock,
       deleteMany: listIntegrationDeleteManyMock,
     },
+    $transaction: prismaTransactionMock,
   },
 }));
 
@@ -209,6 +217,69 @@ describe('list service', () => {
       create: { listId: 5, entryListName: 'Remote list', remoteListId: 12 },
       update: { entryListName: 'Remote list', remoteListId: 12 },
     });
+  });
+
+  it('imports a remote Flexget list into Velara', async () => {
+    findFirstMock.mockResolvedValue(null);
+    getRemoteEntryListsMock.mockResolvedValue([
+      { id: 9, name: 'Remote list', added_on: '2026-01-01' },
+    ]);
+    getRemoteEntryListEntriesMock.mockResolvedValue([
+      { id: 101, title: 'Imported Movie', original_url: 'https://www.themoviedb.org/movie/555' },
+    ]);
+    createMock.mockResolvedValue({
+      id: 10,
+      title: 'Remote list',
+      description: 'Imported from Flexget on 2026-01-01',
+      creator: { id: 11, username: 'alex' },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    prismaTransactionMock.mockResolvedValue([]);
+
+    const { createListService } = await import('./list-service.js');
+    const service = createListService({ logger: loggerMock });
+
+    const imported = await service.importFlexgetList(9, 11);
+
+    expect(imported).toMatchObject({
+      id: 10,
+      title: 'Remote list',
+      description: 'Imported from Flexget on 2026-01-01',
+      creator: { id: 11, username: 'alex' },
+    });
+    expect(imported.createdAt).toBeInstanceOf(Date);
+    expect(imported.updatedAt).toBeInstanceOf(Date);
+
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: { creatorId: 11, title: 'Remote list' },
+      select: { id: true },
+    });
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        title: 'Remote list',
+        description: 'Imported from Flexget on 2026-01-01',
+        creatorId: 11,
+      },
+      include: {
+        creator: { select: { id: true, username: true } },
+      },
+    });
+    expect(prismaTransactionMock).toHaveBeenCalled();
+  });
+
+  it('throws when importing a Flexget list with a duplicate name', async () => {
+    findFirstMock.mockResolvedValue({ id: 20 });
+    getRemoteEntryListsMock.mockResolvedValue([
+      { id: 9, name: 'Remote list', added_on: '2026-01-01' },
+    ]);
+
+    const { createListService } = await import('./list-service.js');
+    const service = createListService({ logger: loggerMock });
+
+    await expect(service.importFlexgetList(9, 11)).rejects.toThrow(
+      'A list with the same name already exists'
+    );
   });
 
   it('adds an item and pushes it to a connected Flexget list', async () => {

--- a/packages/backend/src/lists/list-service.ts
+++ b/packages/backend/src/lists/list-service.ts
@@ -4,7 +4,7 @@ import { LOGGER } from '../registry.js';
 import { prisma } from '../lib/prisma.js';
 import { HttpError } from '../lib/http-error.js';
 import { tmdbClient } from '../movies/tmdb-client.js';
-import { createFlexgetService } from '../flexget/flexget-service.js';
+import { createFlexgetService, type FlexgetEntryListEntry } from '../flexget/flexget-service.js';
 
 type ServiceLogger = Logger | FastifyBaseLogger;
 
@@ -146,6 +146,227 @@ export function createListService(options?: ServiceOptions) {
       default:
         throw new HttpError('Unsupported list item type', { statusCode: 400 });
     }
+  }
+
+  function coerceString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+  }
+
+  function coerceNumber(value: unknown): number | undefined {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+  }
+
+  async function findTmdbMappingByExternalId(
+    externalId: string,
+    source: 'imdb_id' | 'tvdb_id'
+  ): Promise<ListItemInput | null> {
+    try {
+      const response = await tmdbClient
+        .get(`find/${externalId}`, {
+          searchParams: { external_source: source },
+        })
+        .json<{
+          movie_results: { id: number }[];
+          tv_results: { id: number }[];
+          tv_episode_results: Record<string, unknown>[];
+          tv_season_results: Record<string, unknown>[];
+        }>();
+
+      if (response.movie_results?.length > 0) {
+        return { type: 'movie', movieTmdbId: response.movie_results[0].id };
+      }
+
+      if (response.tv_episode_results?.length > 0) {
+        const episode = response.tv_episode_results[0];
+        const seriesTmdbId = coerceString(episode.show_id ?? episode.series_id ?? episode.showId);
+        const seasonNumber = coerceNumber(episode.season_number ?? episode.seasonNumber);
+        const episodeNumber = coerceNumber(episode.episode_number ?? episode.episodeNumber);
+        if (seriesTmdbId && seasonNumber !== undefined && episodeNumber !== undefined) {
+          return {
+            type: 'episode',
+            seriesTmdbId,
+            seasonNumber,
+            episodeNumber,
+          };
+        }
+      }
+
+      if (response.tv_season_results?.length > 0) {
+        const season = response.tv_season_results[0];
+        const seriesTmdbId = coerceString(season.show_id ?? season.series_id ?? season.showId);
+        const seasonNumber = coerceNumber(season.season_number ?? season.seasonNumber);
+        if (seriesTmdbId && seasonNumber !== undefined) {
+          return { type: 'season', seriesTmdbId, seasonNumber };
+        }
+      }
+
+      if (response.tv_results?.length > 0) {
+        return { type: 'series', seriesTmdbId: String(response.tv_results[0].id) };
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function parseTmdbUrlToListItem(url: string): Promise<ListItemInput | null> {
+    try {
+      const parsed = new URL(url);
+      const pathParts = parsed.pathname.replace(/^\/+|\/+$/g, '').split('/');
+      const host = parsed.hostname.toLowerCase();
+
+      if (host.includes('themoviedb.org')) {
+        if (pathParts[0] === 'movie' && pathParts[1]) {
+          const id = coerceNumber(pathParts[1]);
+          if (id !== undefined) return { type: 'movie', movieTmdbId: id };
+        }
+
+        if (pathParts[0] === 'tv' && pathParts[1]) {
+          const seriesTmdbId = String(pathParts[1]);
+          if (pathParts[2] === 'season' && pathParts[3]) {
+            const seasonNumber = coerceNumber(pathParts[3]);
+            if (seasonNumber !== undefined) {
+              if (pathParts[4] === 'episode' && pathParts[5]) {
+                const episodeNumber = coerceNumber(pathParts[5]);
+                if (episodeNumber !== undefined) {
+                  return {
+                    type: 'episode',
+                    seriesTmdbId,
+                    seasonNumber,
+                    episodeNumber,
+                  };
+                }
+              }
+              return { type: 'season', seriesTmdbId, seasonNumber };
+            }
+          }
+          return { type: 'series', seriesTmdbId };
+        }
+      }
+
+      const imdbMatch = /title\/(tt[0-9]+)/.exec(parsed.pathname);
+      if (imdbMatch?.[1]) {
+        return await findTmdbMappingByExternalId(imdbMatch[1], 'imdb_id');
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function mapFlexgetEntryToListItem(entry: FlexgetEntryListEntry): Promise<ListItemInput> {
+    const metadata = entry.entry ?? {};
+    const originalUrl = coerceString(entry.original_url ?? metadata.original_url ?? metadata.url);
+    const imdbId = coerceString(metadata.imdb_id) ?? coerceString(metadata.imdbId);
+    const tvdbId = coerceNumber(metadata.tvdb_id);
+    const seasonNumber = coerceNumber(metadata.season_number);
+    const episodeNumber = coerceNumber(metadata.episode_number);
+
+    if (originalUrl) {
+      const parsed = await parseTmdbUrlToListItem(originalUrl);
+      if (parsed) return parsed;
+    }
+
+    if (imdbId) {
+      const mapped = await findTmdbMappingByExternalId(imdbId, 'imdb_id');
+      if (mapped) return mapped;
+    }
+
+    if (tvdbId !== undefined) {
+      const mapped = await findTmdbMappingByExternalId(String(tvdbId), 'tvdb_id');
+      if (mapped) return mapped;
+    }
+
+    if (
+      seasonNumber !== undefined &&
+      episodeNumber !== undefined &&
+      typeof metadata.series_name === 'string'
+    ) {
+      const seriesTmdbId = coerceString(
+        metadata.series_tmdb_id ?? metadata.seriesId ?? metadata.show_id
+      );
+      if (seriesTmdbId) {
+        return {
+          type: 'episode',
+          seriesTmdbId,
+          seasonNumber,
+          episodeNumber,
+        };
+      }
+    }
+
+    if (seasonNumber !== undefined && typeof metadata.series_name === 'string') {
+      const seriesTmdbId = coerceString(
+        metadata.series_tmdb_id ?? metadata.seriesId ?? metadata.show_id
+      );
+      if (seriesTmdbId) {
+        return { type: 'season', seriesTmdbId, seasonNumber };
+      }
+    }
+
+    throw new HttpError(
+      'Unable to import Flexget list entry because it cannot be mapped to a Velara list item',
+      {
+        statusCode: 502,
+      }
+    );
+  }
+
+  async function buildListItemsFromFlexgetEntries(
+    listId: number,
+    entries: FlexgetEntryListEntry[]
+  ) {
+    const itemData = await Promise.all(
+      entries.map(async entry => buildListItemData(listId, await mapFlexgetEntryToListItem(entry)))
+    );
+
+    await prisma.$transaction(itemData.map(data => prisma.listItem.create({ data })));
+  }
+
+  async function importFlexgetList(remoteListId: number, userId: number) {
+    const logger = localLogger('importFlexgetList');
+    logger.debug({ remoteListId, userId }, 'Importing Flexget list');
+
+    const integration = await flexgetService.ensureIntegration(userId);
+    const remoteLists = await flexgetService.getRemoteEntryLists(integration);
+    const remoteList = remoteLists.find(list => list.id === remoteListId);
+
+    if (!remoteList) {
+      throw new HttpError('Flexget entry list not found', { statusCode: 404 });
+    }
+
+    const existing = await prisma.list.findFirst({
+      where: { creatorId: userId, title: remoteList.name },
+      select: { id: true },
+    });
+
+    if (existing) {
+      throw new HttpError('A list with the same name already exists', { statusCode: 409 });
+    }
+
+    const entries = await flexgetService.getRemoteEntryListEntries(integration, remoteListId);
+    const list = await prisma.list.create({
+      data: {
+        title: remoteList.name,
+        description: remoteList.added_on
+          ? `Imported from Flexget on ${remoteList.added_on}`
+          : 'Imported from Flexget',
+        creatorId: userId,
+      },
+      include: {
+        creator: { select: { id: true, username: true } },
+      },
+    });
+
+    await buildListItemsFromFlexgetEntries(list.id, entries);
+    return list;
   }
 
   function buildListItemData(listId: number, item: ListItemInput, remoteEntryId?: number) {
@@ -307,6 +528,10 @@ export function createListService(options?: ServiceOptions) {
 
       await ensureOwnedList(listId, userId);
       await prisma.listIntegration.deleteMany({ where: { listId } });
+    },
+
+    async importFlexgetList(remoteListId: number, userId: number) {
+      return importFlexgetList(remoteListId, userId);
     },
 
     async addItem(listId: number, item: ListItemInput, userId: number) {

--- a/packages/frontend/src/pages/lists/ListsPage.tsx
+++ b/packages/frontend/src/pages/lists/ListsPage.tsx
@@ -6,9 +6,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
+import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { createList, fetchLists } from '@/services/lists-api';
+import { fetchFlexgetRemoteLists, importFlexgetRemoteList } from '@/services/flexget-api';
 import type { ListSummary } from '@/types/list';
+import type { FlexgetConnection } from '@/services/flexget-api';
 
 export default function ListsPage() {
   const { user, isLoading } = useAuth();
@@ -19,6 +22,12 @@ export default function ListsPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [isLoadingLists, setIsLoadingLists] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
+  const [remoteLists, setRemoteLists] = useState<FlexgetConnection[]>([]);
+  const [selectedRemoteListId, setSelectedRemoteListId] = useState<number | null>(null);
+  const [isLoadingRemoteLists, setIsLoadingRemoteLists] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isLoading && !user) {
@@ -43,6 +52,30 @@ export default function ListsPage() {
 
     loadLists();
   }, [showMine, user]);
+
+  useEffect(() => {
+    if (!isImportDialogOpen || !user) {
+      return;
+    }
+
+    async function loadRemoteLists() {
+      setIsLoadingRemoteLists(true);
+      setImportError(null);
+      setRemoteLists([]);
+      setSelectedRemoteListId(null);
+
+      try {
+        const data = await fetchFlexgetRemoteLists();
+        setRemoteLists(data);
+      } catch {
+        setImportError('Unable to load Flexget entry lists. Check your integration settings.');
+      } finally {
+        setIsLoadingRemoteLists(false);
+      }
+    }
+
+    loadRemoteLists();
+  }, [isImportDialogOpen, user]);
 
   const handleCreateList = async () => {
     if (!title.trim()) {
@@ -75,6 +108,44 @@ export default function ListsPage() {
     }
   };
 
+  const openImportDialog = () => {
+    setImportError(null);
+    setSelectedRemoteListId(null);
+    setIsImportDialogOpen(true);
+  };
+
+  const closeImportDialog = () => {
+    setIsImportDialogOpen(false);
+  };
+
+  const handleImportSelectedList = async () => {
+    if (!selectedRemoteListId) {
+      setImportError('Please select a Flexget list to import.');
+      return;
+    }
+
+    setIsImporting(true);
+    setImportError(null);
+
+    try {
+      const imported = await importFlexgetRemoteList(selectedRemoteListId);
+      setLists(current => [
+        {
+          ...imported,
+          itemCount: 0,
+          description: imported.description ?? null,
+        },
+        ...current,
+      ]);
+      setIsImportDialogOpen(false);
+      toast.success(`Imported ${imported.title} from Flexget.`);
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : 'Unable to import list.');
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   return (
     <div className="space-y-6 pb-16">
       <div className="space-y-1">
@@ -84,7 +155,7 @@ export default function ListsPage() {
         </p>
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-2 items-center">
         <Button
           variant={showMine ? 'default' : 'outline'}
           onClick={() => setShowMine(true)}
@@ -97,6 +168,11 @@ export default function ListsPage() {
           disabled={isLoadingLists}>
           All lists
         </Button>
+        {user ? (
+          <Button variant="secondary" onClick={openImportDialog} disabled={isLoadingLists}>
+            Import from Flexget
+          </Button>
+        ) : null}
       </div>
 
       {user ? (
@@ -155,6 +231,73 @@ export default function ListsPage() {
           </CardContent>
         </Card>
       )}
+
+      {isImportDialogOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-3xl rounded-3xl border border-border bg-background p-6 shadow-xl">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold">Import from Flexget</h2>
+                <p className="text-sm text-muted-foreground">
+                  Select a remote Flexget entry list to import into Velara.
+                </p>
+              </div>
+              <Button variant="ghost" onClick={closeImportDialog}>
+                Close
+              </Button>
+            </div>
+
+            <div className="mt-6 space-y-4">
+              {isLoadingRemoteLists ? (
+                <div className="space-y-3">
+                  <div className="h-4 w-52 rounded-lg bg-muted animate-pulse" />
+                  <div className="h-4 w-32 rounded-lg bg-muted animate-pulse" />
+                </div>
+              ) : remoteLists.length === 0 ? (
+                <div className="rounded-xl border border-muted p-4 text-sm text-muted-foreground">
+                  No Flexget entry lists were found. Make sure your Flexget integration is
+                  configured.
+                </div>
+              ) : (
+                <div className="space-y-2 max-h-72 overflow-y-auto rounded-xl border border-muted p-2">
+                  {remoteLists.map(remoteList => (
+                    <button
+                      key={remoteList.remoteListId}
+                      type="button"
+                      className={`flex w-full items-center justify-between rounded-xl border p-4 text-left transition ${
+                        selectedRemoteListId === remoteList.remoteListId
+                          ? 'border-primary bg-primary/10'
+                          : 'border-transparent hover:border-border'
+                      }`}
+                      onClick={() => setSelectedRemoteListId(remoteList.remoteListId)}>
+                      <div>
+                        <p className="font-medium">{remoteList.entryListName}</p>
+                        <p className="text-xs text-muted-foreground">
+                          ID: {remoteList.remoteListId}
+                        </p>
+                      </div>
+                      <div className="h-4 w-4 rounded-full border border-muted" />
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {importError ? <p className="text-sm text-destructive">{importError}</p> : null}
+
+              <div className="flex flex-wrap gap-2 justify-end">
+                <Button variant="secondary" onClick={closeImportDialog}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleImportSelectedList}
+                  disabled={!selectedRemoteListId || isImporting || remoteLists.length === 0}>
+                  {isImporting ? 'Importing…' : 'Import selected list'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       <div className="space-y-4">
         {isLoadingLists ? (

--- a/packages/frontend/src/services/flexget-api.ts
+++ b/packages/frontend/src/services/flexget-api.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from './api-client';
+import type { ListSummary } from '@/types/list';
 
 export interface FlexgetIntegration {
   baseUrl: string;
@@ -11,6 +12,11 @@ export interface FlexgetIntegrationInput {
   baseUrl: string;
   username: string;
   password: string;
+}
+
+interface RawFlexgetRemoteList {
+  id: number;
+  name: string;
 }
 
 export interface FlexgetConnection {
@@ -38,7 +44,16 @@ export async function deleteFlexgetIntegration(): Promise<void> {
 }
 
 export async function fetchFlexgetRemoteLists(): Promise<FlexgetConnection[]> {
-  return apiRequest<FlexgetConnection[]>('/api/flexget/remote-lists');
+  return apiRequest<RawFlexgetRemoteList[]>('/api/flexget/remote-lists').then(lists =>
+    lists.map(list => ({ entryListName: list.name, remoteListId: list.id }))
+  );
+}
+
+export async function importFlexgetRemoteList(remoteListId: number): Promise<ListSummary> {
+  return apiRequest<ListSummary>('/api/flexget/import', {
+    method: 'POST',
+    body: JSON.stringify({ remoteListId }),
+  });
 }
 
 export async function connectListToFlexget(


### PR DESCRIPTION
- Added backend endpoint to fetch remote Flexget entry lists and import a selected list
- Added duplicate-name validation to prevent importing a list with the same name
- Added frontend import dialog and mapping for remote list names