### PR TITLE
feat: add Flexget TV show begin fallback and UI begin support #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ npm run db:restore
 
 The dump file is written to `packages/backend/db/velara.sql`.
 
+## Development
+
+### Flexget
+
+The flexget API documentation can be found at `http://localhost:5050/api/`
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) if present.

--- a/packages/backend/src/flexget/flexget-routes.ts
+++ b/packages/backend/src/flexget/flexget-routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { authenticate } from '../auth/auth-middleware.js';
 import { createFlexgetService } from './flexget-service.js';
 import { createListService } from '../lists/list-service.js';
+import { createTvShowService } from '../tv-shows/tv-show-service.js';
 
 const integrationBodySchema = z.object({
   baseUrl: z.string().url(),
@@ -61,6 +62,11 @@ export const flexgetRoutes: FastifyPluginCallbackZod = (fastify, _options, done)
     remoteListId: z.coerce.number().int().positive(),
   });
 
+  const setSeriesBeginBodySchema = z.object({
+    seasonNumber: z.number().int().min(1),
+    episodeNumber: z.number().int().min(1),
+  });
+
   fastify.post(
     '/import',
     { preHandler: authenticate, schema: { body: importFlexgetListBodySchema } },
@@ -71,6 +77,31 @@ export const flexgetRoutes: FastifyPluginCallbackZod = (fastify, _options, done)
         request.user.userId
       );
       return reply.code(201).send(list);
+    }
+  );
+
+  fastify.post(
+    '/series/:seriesId/begin',
+    {
+      preHandler: authenticate,
+      schema: {
+        params: z.object({ seriesId: z.string().min(1) }),
+        body: setSeriesBeginBodySchema,
+      },
+    },
+    async (request, reply) => {
+      const integration = await flexgetService.ensureIntegration(request.user.userId);
+      const tvService = createTvShowService({ logger: request.log });
+      const show = await tvService.getTvShowDetails(request.params.seriesId);
+
+      await flexgetService.setSeriesBegin(
+        integration,
+        show.name,
+        request.body.seasonNumber,
+        request.body.episodeNumber
+      );
+
+      return reply.code(204).send();
     }
   );
 

--- a/packages/backend/src/flexget/flexget-service.spec.ts
+++ b/packages/backend/src/flexget/flexget-service.spec.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+vi.mock('../registry.js', () => {
+  const loggerMock = {
+    child: vi.fn().mockReturnThis(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  return {
+    LOGGER: loggerMock,
+    config: {
+      FLEXGET_ALLOW_INSECURE_TLS: false,
+    },
+    __testMocks: {
+      loggerMock,
+    },
+  };
+});
+
+vi.mock('got', () => {
+  const postMock = vi.fn();
+  const getMock = vi.fn();
+  const putMock = vi.fn();
+  const extendMock = vi.fn(() => ({ post: postMock, get: getMock, put: putMock }));
+
+  return {
+    default: {
+      extend: extendMock,
+    },
+    __testMocks: {
+      postMock,
+      getMock,
+      putMock,
+      extendMock,
+    },
+  };
+});
+
+import { createFlexgetService } from './flexget-service.js';
+
+interface TestMock {
+  mockResolvedValueOnce(value: unknown): void;
+  mockResolvedValue(value: unknown): void;
+  mock: { calls: unknown[][] };
+}
+
+describe('Flexget service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets the series begin via Flexget series endpoint', async () => {
+    const gotMock = (await vi.importMock('got')) as {
+      __testMocks: {
+        postMock: TestMock;
+        getMock: TestMock;
+        putMock: TestMock;
+        extendMock: TestMock;
+      };
+    };
+    const { postMock, extendMock } = gotMock.__testMocks;
+
+    postMock.mockResolvedValueOnce({ statusCode: 200, body: {} });
+    postMock.mockResolvedValueOnce({ statusCode: 201, body: { id: 123, name: 'Test Show' } });
+
+    const service = createFlexgetService();
+    const result = await service.setSeriesBegin(
+      {
+        id: 1,
+        userId: 1,
+        baseUrl: 'https://example.com/api',
+        username: 'flexget',
+        password: 'password',
+      },
+      'Test Show',
+      2,
+      5
+    );
+
+    expect(extendMock).toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledWith('auth/login/', {
+      json: { username: 'flexget', password: 'password' },
+    });
+    expect(postMock).toHaveBeenCalledWith('series/', {
+      json: {
+        name: 'Test Show',
+        begin_episode: 'S02E05',
+      },
+    });
+    expect(result).toEqual({ id: 123, name: 'Test Show' });
+  });
+
+  it('updates an existing series begin when Flexget returns 409 conflict', async () => {
+    const gotMock = (await vi.importMock('got')) as {
+      __testMocks: {
+        postMock: TestMock;
+        getMock: TestMock;
+        putMock: TestMock;
+        extendMock: TestMock;
+      };
+    };
+    const { postMock, getMock, putMock } = gotMock.__testMocks;
+
+    postMock.mockResolvedValueOnce({ statusCode: 200, body: {} });
+    postMock.mockResolvedValueOnce({ statusCode: 409, body: { error: 'Conflict' } });
+    postMock.mockResolvedValueOnce({ statusCode: 200, body: {} });
+    getMock.mockResolvedValueOnce({ statusCode: 200, body: [{ id: 42, name: 'Test Show' }] });
+    putMock.mockResolvedValueOnce({
+      statusCode: 200,
+      body: { id: 42, name: 'Test Show', begin_episode: 'S01E01' },
+    });
+
+    const service = createFlexgetService();
+    const result = await service.setSeriesBegin(
+      {
+        id: 1,
+        userId: 1,
+        baseUrl: 'https://example.com/api',
+        username: 'flexget',
+        password: 'password',
+      },
+      'Test Show',
+      1,
+      1
+    );
+
+    expect(postMock).toHaveBeenCalledWith('auth/login/', {
+      json: { username: 'flexget', password: 'password' },
+    });
+    expect(postMock).toHaveBeenCalledWith('series/', {
+      json: { name: 'Test Show', begin_episode: 'S01E01' },
+    });
+    expect(getMock).toHaveBeenCalledWith('series/search/Test%20Show/', {
+      searchParams: { begin: false, latest: false },
+    });
+    expect(putMock).toHaveBeenCalledWith('series/42/', {
+      json: { begin_episode: 'S01E01' },
+    });
+    expect(result).toEqual({ id: 42, name: 'Test Show', begin_episode: 'S01E01' });
+  });
+
+  it('throws an HttpError when Flexget returns an unexpected response while updating an existing series', async () => {
+    const gotMock = (await vi.importMock('got')) as {
+      __testMocks: {
+        postMock: TestMock;
+        getMock: TestMock;
+        putMock: TestMock;
+        extendMock: TestMock;
+      };
+    };
+    const { postMock, getMock, putMock } = gotMock.__testMocks;
+
+    postMock.mockResolvedValueOnce({ statusCode: 200, body: {} });
+    postMock.mockResolvedValueOnce({ statusCode: 409, body: { error: 'Conflict' } });
+    postMock.mockResolvedValueOnce({ statusCode: 200, body: {} });
+    getMock.mockResolvedValueOnce({ statusCode: 200, body: [{ id: 42, name: 'Test Show' }] });
+    putMock.mockResolvedValueOnce({ statusCode: 401, body: { error: 'Unauthorized' } });
+
+    const service = createFlexgetService();
+
+    await expect(
+      service.setSeriesBegin(
+        {
+          id: 1,
+          userId: 1,
+          baseUrl: 'https://example.com/api',
+          username: 'flexget',
+          password: 'password',
+        },
+        'Test Show',
+        1,
+        1
+      )
+    ).rejects.toThrow('Failed to update Flexget series begin');
+  });
+});

--- a/packages/backend/src/flexget/flexget-service.ts
+++ b/packages/backend/src/flexget/flexget-service.ts
@@ -135,6 +135,28 @@ export function createFlexgetService(options?: ServiceOptions) {
     return lists.find(list => list.name === name) ?? null;
   }
 
+  async function findSeriesByName(
+    integration: FlexgetIntegrationRecord,
+    name: string
+  ): Promise<{ id: number; name: string }[]> {
+    const logger = localLogger('findSeriesByName');
+    const client = await authenticateClient(integration);
+
+    const response = await client.get(`series/search/${encodeURIComponent(name)}/`, {
+      searchParams: { begin: false, latest: false },
+    });
+
+    if (response.statusCode !== 200) {
+      logger.error(
+        { statusCode: response.statusCode, body: response.body, name },
+        'Failed to search Flexget series by name'
+      );
+      throw new HttpError('Failed to search Flexget series', { statusCode: 502 });
+    }
+
+    return response.body as unknown as { id: number; name: string }[];
+  }
+
   async function createRemoteEntryList(
     integration: FlexgetIntegrationRecord,
     name: string
@@ -220,6 +242,72 @@ export function createFlexgetService(options?: ServiceOptions) {
     }
   }
 
+  async function setSeriesBegin(
+    integration: FlexgetIntegrationRecord,
+    showName: string,
+    seasonNumber: number,
+    episodeNumber: number
+  ) {
+    const logger = localLogger('setSeriesBegin');
+    const client = await authenticateClient(integration);
+    const beginEpisode = `S${String(seasonNumber).padStart(2, '0')}E${String(
+      episodeNumber
+    ).padStart(2, '0')}`;
+
+    const response = await client.post('series/', {
+      json: {
+        name: showName,
+        begin_episode: beginEpisode,
+      },
+    });
+
+    if (response.statusCode === 409) {
+      const foundSeries = await findSeriesByName(integration, showName);
+      const existing = foundSeries.find(series => series.name === showName) ?? foundSeries[0];
+
+      if (!existing) {
+        throw new HttpError('Flexget series exists but could not be resolved', {
+          statusCode: 502,
+        });
+      }
+
+      const updateResponse = await client.put(`series/${existing.id}/`, {
+        json: { begin_episode: beginEpisode },
+      });
+
+      if (![200, 201].includes(updateResponse.statusCode)) {
+        logger.error(
+          {
+            statusCode: updateResponse.statusCode,
+            body: updateResponse.body,
+            showId: existing.id,
+            beginEpisode,
+          },
+          'Failed to update existing Flexget series begin'
+        );
+        if (updateResponse.statusCode === 404) {
+          throw new HttpError('Flexget show not found', { statusCode: 404 });
+        }
+        throw new HttpError('Failed to update Flexget series begin', { statusCode: 502 });
+      }
+
+      return updateResponse.body;
+    }
+
+    if (![200, 201].includes(response.statusCode)) {
+      logger.error(
+        { statusCode: response.statusCode, body: response.body, showName, beginEpisode },
+        'Failed to set series begin in Flexget'
+      );
+      if (response.statusCode === 404) {
+        throw new HttpError('Flexget show not found', { statusCode: 404 });
+      }
+      throw new HttpError('Failed to update Flexget series begin', { statusCode: 502 });
+    }
+
+    return response.body;
+  }
+
   async function getIntegration(userId: number) {
     const logger = localLogger('getIntegration');
     logger.debug({ userId }, 'Fetching Flexget integration config');
@@ -271,5 +359,6 @@ export function createFlexgetService(options?: ServiceOptions) {
     getRemoteEntryListEntries,
     pushEntryToRemoteList,
     deleteEntryFromRemoteList,
+    setSeriesBegin,
   };
 }

--- a/packages/frontend/src/components/lists/ListItemCard.tsx
+++ b/packages/frontend/src/components/lists/ListItemCard.tsx
@@ -39,7 +39,7 @@ function buildItemMetadata(item: ListItem): Promise<ListItemMetadata> {
           : 'TV series',
         description: show.overview,
         imagePath: show.posterPath,
-        link: `/tv/${show.seriesTmdbId}`,
+        link: `/tv/${show.seriesTmdbId}?list=true`,
       }));
     case 'season':
       return fetchTvSeason(item.seriesTmdbId!, item.seasonNumber!).then((season: TvSeason) => ({
@@ -47,7 +47,7 @@ function buildItemMetadata(item: ListItem): Promise<ListItemMetadata> {
         subtitle: `Season ${season.seasonNumber}`,
         description: season.overview,
         imagePath: season.posterPath,
-        link: `/tv/${item.seriesTmdbId}`,
+        link: `/tv/${item.seriesTmdbId}?list=true`,
       }));
     case 'episode':
       return fetchTvSeason(item.seriesTmdbId!, item.seasonNumber!).then((season: TvSeason) => {
@@ -57,7 +57,7 @@ function buildItemMetadata(item: ListItem): Promise<ListItemMetadata> {
           subtitle: `Season ${season.seasonNumber}${episode ? ` • Episode ${episode.episodeNumber}` : ''}`,
           description: episode?.overview ?? season.overview,
           imagePath: episode?.stillPath ?? season.posterPath,
-          link: `/tv/${item.seriesTmdbId}`,
+          link: `/tv/${item.seriesTmdbId}?list=true`,
         };
       });
     default:

--- a/packages/frontend/src/components/tv-shows/EpisodeRow.tsx
+++ b/packages/frontend/src/components/tv-shows/EpisodeRow.tsx
@@ -1,5 +1,5 @@
-import { useId, useState } from 'react';
-import { Eye, EyeOff } from 'lucide-react';
+import { useId, useState, type MouseEvent } from 'react';
+import { Eye, EyeOff, PlayCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { formatDateTime } from '@/lib/utils';
@@ -10,7 +10,10 @@ interface EpisodeRowProps {
   isWatched: boolean;
   watchedAt?: string | null;
   onToggleWatch: () => void;
+  onSetBegin?: () => void;
+  isBeginPending: boolean;
   isAuthenticated: boolean;
+  isListShow: boolean;
 }
 
 export default function EpisodeRow({
@@ -18,7 +21,10 @@ export default function EpisodeRow({
   isWatched,
   watchedAt,
   onToggleWatch,
+  onSetBegin,
+  isBeginPending,
   isAuthenticated,
+  isListShow,
 }: EpisodeRowProps) {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const tooltipId = useId();
@@ -31,6 +37,11 @@ export default function EpisodeRow({
       }).format(new Date(episode.airDate))
     : null;
   const formattedWatchedAt = watchedAt ? formatDateTime(watchedAt) : null;
+
+  const handleBeginClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onSetBegin?.();
+  };
 
   return (
     <div
@@ -60,6 +71,18 @@ export default function EpisodeRow({
             )}
           </div>
         </div>
+
+        {isAuthenticated && isListShow && !isWatched && onSetBegin && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleBeginClick}
+            disabled={isBeginPending}
+            className="shrink-0 h-7 w-7 p-0">
+            <PlayCircle className="h-3.5 w-3.5" />
+            <span className="sr-only">Set begin from this episode</span>
+          </Button>
+        )}
 
         {isAuthenticated && (
           <Button

--- a/packages/frontend/src/components/tv-shows/SeasonSection.tsx
+++ b/packages/frontend/src/components/tv-shows/SeasonSection.tsx
@@ -13,7 +13,10 @@ interface SeasonSectionProps {
   episodeWatchAt: Map<string, string>;
   seasonRating: number | null;
   isAuthenticated: boolean;
+  isListShow: boolean;
+  isBeginPending: boolean;
   onToggleEpisode: (episode: TvEpisode) => void;
+  onSetBegin: (episode: TvEpisode) => void;
   onSeasonRating: (seasonNumber: number, score: number) => void;
   onClearSeasonRating: (seasonNumber: number) => void;
 }
@@ -23,9 +26,12 @@ export default function SeasonSection({
   watchedEpisodeKeys,
   seasonRating,
   isAuthenticated,
+  isListShow,
+  isBeginPending,
   latestWatchAt,
   episodeWatchAt,
   onToggleEpisode,
+  onSetBegin,
   onSeasonRating,
   onClearSeasonRating,
 }: SeasonSectionProps) {
@@ -99,6 +105,9 @@ export default function SeasonSection({
                 isWatched={watchedEpisodeKeys.has(episodeKey)}
                 watchedAt={episodeWatchAt.get(episodeKey) ?? null}
                 onToggleWatch={() => onToggleEpisode(episode)}
+                onSetBegin={() => onSetBegin(episode)}
+                isListShow={isListShow}
+                isBeginPending={isBeginPending}
                 isAuthenticated={isAuthenticated}
               />
             );

--- a/packages/frontend/src/pages/tv-show-details/TvShowDetailsPage.tsx
+++ b/packages/frontend/src/pages/tv-show-details/TvShowDetailsPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, Calendar, ExternalLink, Trash2, Tv } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -9,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import StarRating from '@/components/movies/StarRating';
 import ListActionPanel from '@/components/lists/ListActionPanel';
 import SeasonSection from '@/components/tv-shows/SeasonSection';
+import { setSeriesBegin } from '@/services/flexget-api';
 import { useTvShowDetails } from '@/hooks/useTvShowDetails';
 import { useTvComments } from '@/hooks/useTvComments';
 import { useUserTvData } from '@/hooks/useUserTvData';
@@ -21,11 +23,34 @@ export default function TvShowDetailsPage() {
   const { seriesId } = useParams<{ seriesId: string }>();
   const id = seriesId ?? '';
   const { user } = useAuth();
+  const [searchParams] = useSearchParams();
+  const isListShow = searchParams.get('list') === 'true';
   const { showQuery, userDataQuery } = useTvShowDetails(id);
   const { commentsQuery, addComment, removeComment } = useTvComments(id);
   const mutations = useUserTvData(id);
   const [reviewText, setReviewText] = useState<string | undefined>(undefined);
   const [commentText, setCommentText] = useState('');
+  const [beginError, setBeginError] = useState<string | null>(null);
+
+  const setSeriesBeginMutation = useMutation<
+    void,
+    Error,
+    { seasonNumber: number; episodeNumber: number }
+  >({
+    mutationFn: ({ seasonNumber, episodeNumber }) =>
+      setSeriesBegin(id, seasonNumber, episodeNumber),
+    onError: error => {
+      setBeginError(error.message || 'Failed to set the series begin episode.');
+    },
+    onSuccess: () => {
+      setBeginError(null);
+    },
+  });
+
+  const handleSetSeriesBegin = (seasonNumber: number, episodeNumber: number) => {
+    setBeginError(null);
+    setSeriesBeginMutation.mutate({ seasonNumber, episodeNumber });
+  };
 
   const show = showQuery.data;
   const userData = userDataQuery.data;
@@ -335,6 +360,12 @@ export default function TvShowDetailsPage() {
 
       <Separator />
 
+      {beginError ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {beginError}
+        </div>
+      ) : null}
+
       {/* Seasons */}
       {show.numberOfSeasons && show.numberOfSeasons > 0 && (
         <div className="space-y-4">
@@ -347,7 +378,10 @@ export default function TvShowDetailsPage() {
             episodeWatchAt={episodeWatchAt}
             seasonRatings={seasonRatings}
             isAuthenticated={!!user}
+            isListShow={isListShow}
+            isBeginPending={setSeriesBeginMutation.isPending}
             onEpisodeToggle={handleEpisodeToggle}
+            onSetBegin={handleSetSeriesBegin}
             onSeasonRating={(seasonNumber, score) =>
               mutations.setSeasonRating.mutate({ seasonNumber, score })
             }
@@ -442,7 +476,10 @@ interface SeasonsListProps {
   episodeWatchAt: Map<string, string>;
   seasonRatings: Record<number, number>;
   isAuthenticated: boolean;
+  isListShow: boolean;
+  isBeginPending: boolean;
   onEpisodeToggle: (seasonNumber: number, episode: TvEpisode) => void;
+  onSetBegin: (seasonNumber: number, episodeNumber: number) => void;
   onSeasonRating: (seasonNumber: number, score: number) => void;
   onClearSeasonRating: (seasonNumber: number) => void;
 }
@@ -455,7 +492,10 @@ function SeasonsList({
   episodeWatchAt,
   seasonRatings,
   isAuthenticated,
+  isListShow,
+  isBeginPending,
   onEpisodeToggle,
+  onSetBegin,
   onSeasonRating,
   onClearSeasonRating,
 }: SeasonsListProps) {
@@ -473,7 +513,10 @@ function SeasonsList({
           episodeWatchAt={episodeWatchAt}
           seasonRating={seasonRatings[n] ?? null}
           isAuthenticated={isAuthenticated}
+          isListShow={isListShow}
+          isBeginPending={isBeginPending}
           onEpisodeToggle={onEpisodeToggle}
+          onSetBegin={onSetBegin}
           onSeasonRating={onSeasonRating}
           onClearSeasonRating={onClearSeasonRating}
         />
@@ -490,7 +533,10 @@ interface SeasonLoaderProps {
   episodeWatchAt: Map<string, string>;
   seasonRating: number | null;
   isAuthenticated: boolean;
+  isListShow: boolean;
+  isBeginPending: boolean;
   onEpisodeToggle: (seasonNumber: number, episode: TvEpisode) => void;
+  onSetBegin: (seasonNumber: number, episodeNumber: number) => void;
   onSeasonRating: (seasonNumber: number, score: number) => void;
   onClearSeasonRating: (seasonNumber: number) => void;
 }
@@ -503,7 +549,10 @@ function SeasonLoader({
   episodeWatchAt,
   seasonRating,
   isAuthenticated,
+  isListShow,
+  isBeginPending,
   onEpisodeToggle,
+  onSetBegin,
   onSeasonRating,
   onClearSeasonRating,
 }: SeasonLoaderProps) {
@@ -521,7 +570,10 @@ function SeasonLoader({
       episodeWatchAt={episodeWatchAt}
       seasonRating={seasonRating}
       isAuthenticated={isAuthenticated}
+      isListShow={isListShow}
+      isBeginPending={isBeginPending}
       onToggleEpisode={episode => onEpisodeToggle(seasonNumber, episode)}
+      onSetBegin={episode => onSetBegin(seasonNumber, episode.episodeNumber)}
       onSeasonRating={onSeasonRating}
       onClearSeasonRating={onClearSeasonRating}
     />

--- a/packages/frontend/src/services/flexget-api.ts
+++ b/packages/frontend/src/services/flexget-api.ts
@@ -56,6 +56,17 @@ export async function importFlexgetRemoteList(remoteListId: number): Promise<Lis
   });
 }
 
+export async function setSeriesBegin(
+  seriesId: string,
+  seasonNumber: number,
+  episodeNumber: number
+): Promise<void> {
+  return apiRequest<void>(`/api/flexget/series/${seriesId}/begin`, {
+    method: 'POST',
+    body: JSON.stringify({ seasonNumber, episodeNumber }),
+  });
+}
+
 export async function connectListToFlexget(
   listId: number,
   entryListName: string


### PR DESCRIPTION
This PR adds Flexget integration support for setting a TV show season/episode begin point.

- Implements /api/flexget/series/:seriesId/begin backend route.
- Handles 409 conflict by searching existing Flexget series and updating with PUT.
- Adds frontend UI support for list-connected TV show begin actions.
- Includes backend tests covering the 409 fallback path.

Fixes #33